### PR TITLE
chore: add flow path to workspace settings of all packages

### DIFF
--- a/packages/polymath-auth/.vscode/settings.json
+++ b/packages/polymath-auth/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "flow.pathToFlow": "./node_modules/.bin/flow"
+}

--- a/packages/polymath-investor/.vscode/settings.json
+++ b/packages/polymath-investor/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "flow.pathToFlow": "./node_modules/.bin/flow"
+}

--- a/packages/polymath-issuer/.vscode/settings.json
+++ b/packages/polymath-issuer/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "flow.pathToFlow": "./node_modules/.bin/flow"
+}

--- a/packages/polymath-js/.vscode/settings.json
+++ b/packages/polymath-js/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "flow.pathToFlow": "./node_modules/.bin/flow"
+}

--- a/packages/polymath-offchain/.vscode/settings.json
+++ b/packages/polymath-offchain/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "flow.pathToFlow": "./node_modules/.bin/flow"
+}

--- a/packages/polymath-scripts/.vscode/settings.json
+++ b/packages/polymath-scripts/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "flow.pathToFlow": "./node_modules/.bin/flow"
+}

--- a/packages/polymath-ui/.vscode/settings.json
+++ b/packages/polymath-ui/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "flow.pathToFlow": "./node_modules/.bin/flow"
+}


### PR DESCRIPTION
This PR adds the pathToFlow workspace setting to each package individually, to enable flow when opening an individual package in the editor