### PR TITLE
Fix/auth move node urls to env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@
 
 This is a monorepo containing the webapps and libraries in Polymath. In each package you will find a _Readme_ that describes it.
 
+# Apps and packages
+
+- [Polymath Issuer](https://github.com/PolymathNetwork/polymath-apps/blob/develop/packages/polymath-issuer/README.md)
+- [Polymath Investor](https://github.com/PolymathNetwork/polymath-apps/blob/develop/packages/polymath-investor/README.md)
+
 # Setup
 
 In the root of the repository run:

--- a/packages/polymath-investor/.env.local
+++ b/packages/polymath-investor/.env.local
@@ -1,0 +1,26 @@
+#
+# Blockchain node URLs
+# ------------------------------------------------------------------------------
+# * REACT_APP_NETWORK_KOVAN_WS: Kovan node's websocket url
+# * REACT_APP_NETWORK_MAIN_WS: Mainnet node's websocket url
+# * REACT_APP_NETWORK_LOCAL_WS: Local blockchain network's url 
+# * REACT_APP_NODE_WS: Legacy env variable used to override websocket url to
+#  network.
+#  TODO @RafaelVidaurre: This is not defaulting to ganache on localhost right now since auth
+#  doesnt support it yet.
+#
+# Server
+# ------------------------------------------------------------------------------
+# PORT: Web server's port
+#
+# Apps
+# ------------------------------------------------------------------------------
+# * REACT_APP_POLYMATH_OFFCHAIN_ADDRESS: The http adress of the `offchain`
+#  service.
+#  TODO @RafaelVidaurre: This should default to localhost once offchain is
+#  finished.
+#
+
+
+PORT=3000
+REACT_APP_NETWORK_LOCAL_WS=ws://localhost:8545

--- a/packages/polymath-investor/README.md
+++ b/packages/polymath-investor/README.md
@@ -2,49 +2,11 @@
 
 ![Polymath](Polymath.png)
 
-# Polymath Investor Application
-
-Allows you to invest in STO.
-
-
 ## Development
-After cloning, to install all dependencies run:
-```
-yarn
-```
-We only use Yarn as our official Node package manager, so we will only commit yarn.lock files and ignore package-lock.json files.
 
-To start development run:
-```
-yarn start
-```
+# Environment variables
 
-To build application run:
-```
-yarn build
-```
+You can set the following env vars inside a `.env` file on the package's root
 
-By default application works with Kovan testnet.
-
-## Working with contracts locally
-
-Start the ganache cli
-
-**Important: The `contracts` command will fail if `ganache-cli` is not running**
-```
-yarn ganache-cli
-```
-
-In a separate terminal:
-```
-yarn contracts
-```
-
-Turn off MetaMask or any other Web3 provider and start/build application.
-
-To open Truffle Console and play with contracts directly:
-```
-yarn tconsole
-```
-
-[Read more about Truffle Console](http://truffleframework.com/docs/getting_started/console)
+`REACT_APP_NETWORK_KOVAN_WS`: To connect to Kovan locally
+`REACT_APP_NETWORK_MAIN_WS`: To connect to the Mainnet locally

--- a/packages/polymath-issuer/.env.local
+++ b/packages/polymath-issuer/.env.local
@@ -1,7 +1,26 @@
-# FIXME @RafaelVidaurre:
-# - Set REACT_APP_POLYMATH_OFFCHAIN_ADDRESS as default when offchain is re-engineered
-# - Rename REACT_APP_NODE_WS to something more descriptive
-# - Re enable app to by default connect to localhost blockchain
-# REACT_APP_POLYMATH_OFFCHAIN_ADDRESS=http://localhost:3001
-# REACT_APP_NODE_WS=ws://localhost:8545
+#
+# Blockchain node URLs
+# ------------------------------------------------------------------------------
+# * REACT_APP_NETWORK_KOVAN_WS: Kovan node's websocket url
+# * REACT_APP_NETWORK_MAIN_WS: Mainnet node's websocket url
+# * REACT_APP_NETWORK_LOCAL_WS: Local blockchain network's url 
+# * REACT_APP_NODE_WS: Legacy env variable used to override websocket url to
+#  network.
+#  TODO @RafaelVidaurre: This is not defaulting to ganache on localhost right now since auth
+#  doesnt support it yet.
+#
+# Server
+# ------------------------------------------------------------------------------
+# PORT: Web server's port
+#
+# Apps
+# ------------------------------------------------------------------------------
+# * REACT_APP_POLYMATH_OFFCHAIN_ADDRESS: The http adress of the `offchain`
+#  service.
+#  TODO @RafaelVidaurre: This should default to localhost once offchain is
+#  finished.
+#
+
+
 PORT=3000
+REACT_APP_NETWORK_LOCAL_WS=ws://localhost:8545

--- a/packages/polymath-issuer/README.md
+++ b/packages/polymath-issuer/README.md
@@ -2,55 +2,11 @@
 
 ![Polymath](Polymath.png)
 
-# Polymath Issuer Application
-
-Allows you to issue your security token and launch its offering.
-
-
 ## Development
-After cloning, to install all dependencies run:
-```
-yarn
-```
 
-We only use [Yarn](https://yarnpkg.com/en/) as our official Node package manager, so we will only commit yarn.lock files and ignore package-lock.json files.
+# Environment variables
 
+You can set the following env vars inside a `.env` file on the package's root
 
-On development we recommend to run the app with contracts locally. To do
-this follow [this steps](#working-with-contracts-locally) before starting the 
-app.
-
-**Important: When working with contracts locally, you must wait for the
-`contracts` command to finish before starting the application. Otherwise
-you will receive a runtime error.**
-
-To start development run:
-```
-yarn start
-```
-
-To build the application run:
-```
-yarn build
-```
-
-## Working with contracts locally
-
-Start the [Ganache CLI](https://github.com/trufflesuite/ganache-cli) to run the local blockchain:
-
-**Important: The `contracts` command will fail if `ganache-cli` is not running**
-```
-yarn ganache-cli
-```
-
-In a separate terminal, generate the contract artifacts:
-```
-yarn contracts
-```
-
-Turn off [MetaMask](https://metamask.io/) or any other [Web3](https://github.com/ethereum/web3.js/) provider and start/build application.
-
-To open [Truffle Console](http://truffleframework.com/docs/getting_started/console) and play with contracts directly:
-```
-yarn tconsole
-```
+`REACT_APP_NETWORK_KOVAN_WS`: To connect to Kovan locally
+`REACT_APP_NETWORK_MAIN_WS`: To connect to the Mainnet locally

--- a/packages/polymath-ui/src/components/EthNetworkWrapper/networks.js
+++ b/packages/polymath-ui/src/components/EthNetworkWrapper/networks.js
@@ -14,8 +14,7 @@ export default (id: string = 'local'): Network =>
   ({
     [NETWORK_MAIN]: {
       name: 'Mainnet',
-      url:
-        'wss://easily-complete-starfish.quiknode.io/99f426a7-0f3d-427b-aae2-df6ad61fcf1e/lh7cRkafeab5UaYu4OpQpA==/',
+      url: process.env.REACT_APP_NETWORK_MAIN_WS,
     },
     [NETWORK_ROPSTEN]: {
       name: 'Ropsten Testnet',
@@ -27,11 +26,10 @@ export default (id: string = 'local'): Network =>
     },
     [NETWORK_KOVAN]: {
       name: 'Kovan Testnet',
-      url:
-        'wss://heartily-internal-escargot.quiknode.io/46df7525-5518-428e-b30b-9dea09480213/4oM662IRx_2tZJq3ht4wdQ==/',
+      url: process.env.REACT_APP_NETWORK_KOVAN_WS,
     },
     local: {
       name: 'Localhost',
-      url: 'ws://localhost:8545',
+      url: process.env.REACT_APP_NETWORK_LOCAL_WS,
     },
   }[id]);


### PR DESCRIPTION
* Moves `polymath-auth`'s hard-coded URLs into env variables.
* Updates documentation

**IMPORTANT:** If you are planning on using `Kovan` locally, you **must** set the `REACT_APP_NETWORK_KOVAN_WS` env variable in the proper app pointing to the node's URL (I'll share this to you privately).

Also, note that this will most likely change soon, this is just so that we can keep working with the updated node urls