### PR TITLE
fix(issuer): export csv without popup

### DIFF
--- a/packages/polymath-issuer/src/actions/compliance.js
+++ b/packages/polymath-issuer/src/actions/compliance.js
@@ -239,7 +239,7 @@ export const exportWhitelist = () => async (
         ].join(',');
     });
 
-    window.open(encodeURI(csvContent));
+    window.location.assign(encodeURI(csvContent));
 
     dispatch(ui.fetched());
   } catch (e) {


### PR DESCRIPTION
This removes the need to open a popup window to download the csv export.