### PR TITLE
Chore/support end to end test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ To run unit tests for a specific app run:
 
 ## E2E Tests
 
+To also enable test coverage reports for **E2E tests** set `COVERAGE=true` in
+your environment
+
 _Instructions pending_
 
 # How to contribute

--- a/config/babel.config.js
+++ b/config/babel.config.js
@@ -1,21 +1,47 @@
-module.exports = {
-  moduleResolver: [
-    'module-resolver',
-    {
-      root: ['./src'],
-      alias: {
-        /* Avoid resolving to "src" when importing "build" directory */
-        '^@polymathnetwork/([^/]+)/build/(.+)':
-          '@polymathnetwork/\\1/build/\\2',
-        /* Resolve local dependencies to their src directory */
-        '^@polymathnetwork/([^/]+)/(.+)': '@polymathnetwork/\\1/src/\\2',
-        '^@polymathnetwork/(.+)$': '@polymathnetwork/\\1/src',
-        /* Consider package.json as special case */
-        '^@polymathnetwork/([^/]+)/package.json':
-          '@polymathnetwork/\\1/package.json',
-        /* TODO @RafaelVidaurre: See if this is necessary */
-        '^@polymathnetwork/(.+)': '@polymathnetwork/\\1',
-      },
+const instrumentForCodeCoverage = process.env.COVERAGE === 'true';
+
+/**
+ * Resolves imports between namespace packages
+ * from `package-name/*` to `package-name/src/*`
+ * This allows importing source files between packages without requiring
+ * them to be already compiled
+ */
+const moduleResolverPlugin = [
+  'module-resolver',
+  {
+    root: ['./src'],
+    alias: {
+      /* Avoid resolving to "src" when importing "build" directory */
+      '^@polymathnetwork/([^/]+)/build/(.+)': '@polymathnetwork/\\1/build/\\2',
+      /* Resolve local dependencies to their src directory */
+      '^@polymathnetwork/([^/]+)/(.+)': '@polymathnetwork/\\1/src/\\2',
+      '^@polymathnetwork/(.+)$': '@polymathnetwork/\\1/src',
+      /* Consider package.json as special case */
+      '^@polymathnetwork/([^/]+)/package.json':
+        '@polymathnetwork/\\1/package.json',
+      /* TODO @RafaelVidaurre: See if this is necessary */
+      '^@polymathnetwork/(.+)': '@polymathnetwork/\\1',
     },
+  },
+];
+
+/**
+ * Used by e2e tests. Instruments the code to expose coverage
+ * info to the browser
+ */
+const istanbulPlugin = [
+  'istanbul',
+  {
+    exclude: '**/__tests__/**/*',
+    useInlineSourceMaps: false,
+  },
+];
+
+module.exports = {
+  plugins: [
+    '@babel/proposal-export-default-from',
+    '@babel/proposal-class-properties',
+    moduleResolverPlugin,
+    ...(instrumentForCodeCoverage ? istanbulPlugin : []),
   ],
 };

--- a/config/babel.config.js
+++ b/config/babel.config.js
@@ -42,6 +42,6 @@ module.exports = {
     '@babel/proposal-export-default-from',
     '@babel/proposal-class-properties',
     moduleResolverPlugin,
-    ...(instrumentForCodeCoverage ? istanbulPlugin : []),
+    ...(instrumentForCodeCoverage ? [istanbulPlugin] : []),
   ],
 };

--- a/packages/polymath-investor/babel.config.js
+++ b/packages/polymath-investor/babel.config.js
@@ -3,9 +3,5 @@ const base = require('../../config/babel.config.js');
 module.exports = {
   babelrcRoots: ['../packages/*'],
   presets: ['react-app'],
-  plugins: [
-    '@babel/proposal-export-default-from',
-    '@babel/proposal-class-properties',
-    base.moduleResolver,
-  ],
+  plugins: [...base.plugins],
 };

--- a/packages/polymath-issuer/babel.config.js
+++ b/packages/polymath-issuer/babel.config.js
@@ -3,9 +3,5 @@ const base = require('../../config/babel.config.js');
 module.exports = {
   babelrcRoots: ['../packages/*'],
   presets: ['react-app'],
-  plugins: [
-    '@babel/proposal-export-default-from',
-    '@babel/proposal-class-properties',
-    base.moduleResolver,
-  ],
+  plugins: [...base.plugins],
 };

--- a/packages/polymath-issuer/package.json
+++ b/packages/polymath-issuer/package.json
@@ -62,6 +62,7 @@
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "22.4.3",
     "babel-loader": "^8.0.2",
+    "babel-plugin-istanbul": "^5.0.1",
     "babel-plugin-module-resolver": "^3.1.1",
     "babel-plugin-named-asset-import": "1.0.0-next.a671462c",
     "babel-preset-react-app": "4.0.0-next.a671462c",

--- a/packages/polymath-js/babel.config.js
+++ b/packages/polymath-js/babel.config.js
@@ -3,12 +3,10 @@ module.exports = {
   babelrcRoots: ['../packages/*'],
   presets: ['@babel/flow', '@babel/env'],
   plugins: [
+    ...base.plugins,
     '@babel/plugin-proposal-object-rest-spread',
-    '@babel/proposal-export-default-from',
-    '@babel/proposal-class-properties',
     '@babel/plugin-transform-runtime',
     '@babel/plugin-syntax-async-generators',
     '@babel/plugin-transform-regenerator',
-    base.moduleResolver,
   ],
 };

--- a/packages/polymath-offchain/babel.config.js
+++ b/packages/polymath-offchain/babel.config.js
@@ -3,12 +3,10 @@ module.exports = {
   babelrcRoots: ['../packages/*'],
   presets: ['@babel/flow', '@babel/env', '@babel/react'],
   plugins: [
+    ...base.plugins,
     '@babel/plugin-proposal-object-rest-spread',
-    '@babel/proposal-export-default-from',
-    '@babel/proposal-class-properties',
     '@babel/plugin-transform-runtime',
     '@babel/plugin-syntax-async-generators',
     '@babel/plugin-transform-regenerator',
-    base.moduleResolver,
   ],
 };

--- a/packages/polymath-ui/babel.config.js
+++ b/packages/polymath-ui/babel.config.js
@@ -3,12 +3,10 @@ module.exports = {
   babelrcRoots: ['../packages/*'],
   presets: ['@babel/flow', '@babel/env', '@babel/react'],
   plugins: [
+    ...base.plugins,
     '@babel/plugin-proposal-object-rest-spread',
-    '@babel/proposal-export-default-from',
-    '@babel/proposal-class-properties',
     '@babel/plugin-transform-runtime',
     '@babel/plugin-syntax-async-generators',
     '@babel/plugin-transform-regenerator',
-    base.moduleResolver,
   ],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,6 +32,12 @@
   dependencies:
     "@babel/highlight" "7.0.0-beta.46"
 
+"@babel/code-frame@7.0.0-beta.51":
+  version "7.0.0-beta.51"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.51.tgz#bd71d9b192af978df915829d39d4094456439a0c"
+  dependencies:
+    "@babel/highlight" "7.0.0-beta.51"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.0.0-beta.35":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8"
@@ -103,6 +109,16 @@
     "@babel/types" "7.0.0-beta.46"
     jsesc "^2.5.1"
     lodash "^4.2.0"
+    source-map "^0.5.0"
+    trim-right "^1.0.1"
+
+"@babel/generator@7.0.0-beta.51":
+  version "7.0.0-beta.51"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.0.0-beta.51.tgz#6c7575ffde761d07485e04baedc0392c6d9e30f6"
+  dependencies:
+    "@babel/types" "7.0.0-beta.51"
+    jsesc "^2.5.1"
+    lodash "^4.17.5"
     source-map "^0.5.0"
     trim-right "^1.0.1"
 
@@ -219,6 +235,14 @@
     "@babel/template" "7.0.0-beta.46"
     "@babel/types" "7.0.0-beta.46"
 
+"@babel/helper-function-name@7.0.0-beta.51":
+  version "7.0.0-beta.51"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.51.tgz#21b4874a227cf99ecafcc30a90302da5a2640561"
+  dependencies:
+    "@babel/helper-get-function-arity" "7.0.0-beta.51"
+    "@babel/template" "7.0.0-beta.51"
+    "@babel/types" "7.0.0-beta.51"
+
 "@babel/helper-function-name@^7.0.0", "@babel/helper-function-name@^7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz#a0ceb01685f73355d4360c1247f582bfafc8ff53"
@@ -238,6 +262,12 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.46.tgz#7161bfe449b4183dbe25d1fe5579338b7429e5f2"
   dependencies:
     "@babel/types" "7.0.0-beta.46"
+
+"@babel/helper-get-function-arity@7.0.0-beta.51":
+  version "7.0.0-beta.51"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.51.tgz#3281b2d045af95c172ce91b20825d85ea4676411"
+  dependencies:
+    "@babel/types" "7.0.0-beta.51"
 
 "@babel/helper-get-function-arity@^7.0.0":
   version "7.0.0"
@@ -395,6 +425,12 @@
   dependencies:
     "@babel/types" "7.0.0-beta.46"
 
+"@babel/helper-split-export-declaration@7.0.0-beta.51":
+  version "7.0.0-beta.51"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.51.tgz#8a6c3f66c4d265352fc077484f9f6e80a51ab978"
+  dependencies:
+    "@babel/types" "7.0.0-beta.51"
+
 "@babel/helper-split-export-declaration@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz#3aae285c0311c2ab095d997b8c9a94cad547d813"
@@ -443,6 +479,14 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
+"@babel/highlight@7.0.0-beta.51":
+  version "7.0.0-beta.51"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0-beta.51.tgz#e8844ae25a1595ccfd42b89623b4376ca06d225d"
+  dependencies:
+    chalk "^2.0.0"
+    esutils "^2.0.2"
+    js-tokens "^3.0.0"
+
 "@babel/highlight@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0.tgz#f710c38c8d458e6dd9a201afb637fcb781ce99e4"
@@ -462,6 +506,10 @@
     lodash "^4.17.10"
     output-file-sync "^2.0.0"
     v8flags "^3.1.1"
+
+"@babel/parser@7.0.0-beta.51":
+  version "7.0.0-beta.51"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.0.0-beta.51.tgz#27cec2df409df60af58270ed8f6aa55409ea86f6"
 
 "@babel/parser@7.0.0-beta.53":
   version "7.0.0-beta.53"
@@ -1381,6 +1429,15 @@
     babylon "7.0.0-beta.46"
     lodash "^4.2.0"
 
+"@babel/template@7.0.0-beta.51":
+  version "7.0.0-beta.51"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.51.tgz#9602a40aebcf357ae9677e2532ef5fc810f5fbff"
+  dependencies:
+    "@babel/code-frame" "7.0.0-beta.51"
+    "@babel/parser" "7.0.0-beta.51"
+    "@babel/types" "7.0.0-beta.51"
+    lodash "^4.17.5"
+
 "@babel/template@^7.0.0", "@babel/template@^7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.1.0.tgz#58cc9572e1bfe24fe1537fdf99d839d53e517e22"
@@ -1417,6 +1474,21 @@
     invariant "^2.2.0"
     lodash "^4.2.0"
 
+"@babel/traverse@7.0.0-beta.51":
+  version "7.0.0-beta.51"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.0.0-beta.51.tgz#981daf2cec347a6231d3aa1d9e1803b03aaaa4a8"
+  dependencies:
+    "@babel/code-frame" "7.0.0-beta.51"
+    "@babel/generator" "7.0.0-beta.51"
+    "@babel/helper-function-name" "7.0.0-beta.51"
+    "@babel/helper-split-export-declaration" "7.0.0-beta.51"
+    "@babel/parser" "7.0.0-beta.51"
+    "@babel/types" "7.0.0-beta.51"
+    debug "^3.1.0"
+    globals "^11.1.0"
+    invariant "^2.2.0"
+    lodash "^4.17.5"
+
 "@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.1.0.tgz#503ec6669387efd182c3888c4eec07bcc45d91b2"
@@ -1445,6 +1517,14 @@
   dependencies:
     esutils "^2.0.2"
     lodash "^4.2.0"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@7.0.0-beta.51":
+  version "7.0.0-beta.51"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.51.tgz#d802b7b543b5836c778aa691797abf00f3d97ea9"
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.5"
     to-fast-properties "^2.0.0"
 
 "@babel/types@^7.0.0":
@@ -3292,6 +3372,14 @@ babel-plugin-istanbul@^4.1.5, babel-plugin-istanbul@^4.1.6:
     find-up "^2.1.0"
     istanbul-lib-instrument "^1.10.1"
     test-exclude "^4.2.1"
+
+babel-plugin-istanbul@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-5.0.1.tgz#2ce7bf211f0d9480ff7fd294bd05e2fa555e31ea"
+  dependencies:
+    find-up "^3.0.0"
+    istanbul-lib-instrument "^2.2.0"
+    test-exclude "^5.0.0"
 
 babel-plugin-jest-hoist@^22.4.4:
   version "22.4.4"
@@ -9798,6 +9886,10 @@ istanbul-lib-coverage@^1.1.1, istanbul-lib-coverage@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.1.tgz#ccf7edcd0a0bb9b8f729feeb0930470f9af664f0"
 
+istanbul-lib-coverage@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#2aee0e073ad8c5f6a0b00e0dfbf52b4667472eda"
+
 istanbul-lib-hook@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-1.2.2.tgz#bc6bf07f12a641fbf1c85391d0daa8f0aea6bf86"
@@ -9815,6 +9907,18 @@ istanbul-lib-instrument@^1.10.1, istanbul-lib-instrument@^1.10.2, istanbul-lib-i
     babylon "^6.18.0"
     istanbul-lib-coverage "^1.2.1"
     semver "^5.3.0"
+
+istanbul-lib-instrument@^2.2.0:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-2.3.2.tgz#b287cbae2b5f65f3567b05e2e29b275eaf92d25e"
+  dependencies:
+    "@babel/generator" "7.0.0-beta.51"
+    "@babel/parser" "7.0.0-beta.51"
+    "@babel/template" "7.0.0-beta.51"
+    "@babel/traverse" "7.0.0-beta.51"
+    "@babel/types" "7.0.0-beta.51"
+    istanbul-lib-coverage "^2.0.1"
+    semver "^5.5.0"
 
 istanbul-lib-report@^1.1.5:
   version "1.1.5"
@@ -14053,6 +14157,13 @@ read-pkg-up@^3.0.0:
     find-up "^2.0.0"
     read-pkg "^3.0.0"
 
+read-pkg-up@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-4.0.0.tgz#1b221c6088ba7799601c808f91161c66e58f8978"
+  dependencies:
+    find-up "^3.0.0"
+    read-pkg "^3.0.0"
+
 read-pkg@^1.0.0, read-pkg@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-1.1.0.tgz#f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28"
@@ -16123,6 +16234,15 @@ test-exclude@^4.2.1:
     micromatch "^2.3.11"
     object-assign "^4.1.0"
     read-pkg-up "^1.0.1"
+    require-main-filename "^1.0.1"
+
+test-exclude@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-5.0.0.tgz#cdce7cece785e0e829cd5c2b27baf18bc583cfb7"
+  dependencies:
+    arrify "^1.0.1"
+    minimatch "^3.0.4"
+    read-pkg-up "^4.0.0"
     require-main-filename "^1.0.1"
 
 text-extensions@^1.0.0:


### PR DESCRIPTION
- Adds `istanbul` coverage instrumentation for end-to-end tests. Enabled through `COVERAGE` env variable
- Tidies up the overall babel config (#48)