### PR TITLE
fix(offchain): don't log errors that are not defined

### DIFF
--- a/packages/polymath-offchain/src/startup/setupWeb3.js
+++ b/packages/polymath-offchain/src/startup/setupWeb3.js
@@ -92,7 +92,10 @@ const newProvider = () => {
     Reconnect when socket connection errors or ends
    */
   provider.on('error', error => {
-    logger.error(error.message, error);
+    if (error && error.message) {
+      logger.error(error.message, error);
+    }
+
     logger.info(`[SETUP] Reconnecting socket after error...`);
     connectWeb3();
   });


### PR DESCRIPTION
A Web3 implementation mistake causes some socket error events to pass the error to the callback, and others to simply log it to the console directly without passing them to the callback. I simply fixed it

**Please make sure the following boxes are checked before submitting your Pull Request:**

- [x] I linked the issues related to this PR in its description (if any).
- [x] If this PR adds new code that is not going to change in the near future, it includes unit tests to cover it.
