### PR TITLE
chore(offchain): ignore build tests, restore console reporting

### DIFF
--- a/packages/polymath-offchain/.gitignore
+++ b/packages/polymath-offchain/.gitignore
@@ -6,3 +6,4 @@ package-lock.json
 yarn-error.log
 .env
 /coverage
+junit.xml

--- a/packages/polymath-offchain/package.json
+++ b/packages/polymath-offchain/package.json
@@ -55,7 +55,7 @@
   "jest": {
     "testEnvironment": "node",
     "testMatch": [
-      "**/__tests__/**/*.{js}"
+      "<rootDir>/src/**/__tests__/**/*.{js}"
     ],
     "collectCoverageFrom": [
       "src/**/*.{js,jsx}",
@@ -71,11 +71,13 @@
     ],
     "coverageReporters": [
       "lcov",
-      "cobertura"
+      "cobertura",
+      "text"
     ],
     "coverageDirectory": "<rootDir>/reports",
     "reporters": [
-      "jest-junit"
+      "jest-junit",
+      "default"
     ]
   }
 }


### PR DESCRIPTION
This PR ignores tests in the /build folder and makes it so that test results are reported to the console as well as the other reporters. It also ignores junit.xml from being commited to the repo

**Please make sure the following boxes are checked before submitting your Pull Request:**

- [x] I linked the issues related to this PR in its description (if any).
- [x] If this PR adds new code that is not going to change in the near future, it includes unit tests to cover it.
