### PR TITLE
fix(issuer): position properly select component carret

### DIFF
--- a/packages/polymath-ui/src/styles/globals.scss
+++ b/packages/polymath-ui/src/styles/globals.scss
@@ -276,6 +276,7 @@ div {
 
   .bx--select__arrow {
     fill: $poly-blue-dark !important;
+    top: 3rem; // hack due to Carbon component not supporting multiline errors
   }
 }
 


### PR DESCRIPTION
Ugly hack cause of Carbon component structure.

![screen shot 2018-10-16 at 13 10 51](https://user-images.githubusercontent.com/527559/47031139-a79f8c80-d145-11e8-81b1-7060a1fc745e.jpg)
