### PR TITLE
fix(shared): add 1 second blocktime to ganache-cli

### DIFF
--- a/packages/polymath-shared/package.json
+++ b/packages/polymath-shared/package.json
@@ -7,7 +7,7 @@
     "node": ">=8.9"
   },
   "scripts": {
-    "local-blockchain:start": "yarn local-blockchain:prepare && yarn ganache-cli --db=\"./build/fixtures/blockchain-state/\" --gasLimit 90000000 -i=15 -d --mnemonic=\"candy maple cake sugar pudding cream honey rich smooth crumble sweet treat\"",
+    "local-blockchain:start": "yarn local-blockchain:prepare && yarn ganache-cli --db=\"./build/fixtures/blockchain-state/\" --gasLimit 90000000 -i=15 -d --mnemonic=\"candy maple cake sugar pudding cream honey rich smooth crumble sweet treat\" --blockTime 1",
     "local-blockchain:prepare": "rm -rf ./build && mkdir build && cp -r ./src/fixtures ./build/fixtures",
     "local-blockchain:migrate": "echo \"DEPRECATED: No need to run migrate locally anymore. The local blockchain now starts ready to go.\"",
     "local-blockchain:console": "truffle console",


### PR DESCRIPTION
This fixes problems caused by Metamask caching some blockchain responses (which was responsible for POLY not being updated when using the local faucet)

**Please make sure the following boxes are checked before submitting your Pull Request:**

- [x] I linked the issues related to this PR in its description (if any).
- [x] If this PR adds new code that is not going to change in the near future, it includes unit tests to cover it.
