### PR TITLE
feat(shared): use kovan staging addresses

### DIFF
--- a/packages/polymath-shared/src/__tests__/constants.js
+++ b/packages/polymath-shared/src/__tests__/constants.js
@@ -1,5 +1,5 @@
 import tickerRegistryArtifact from '../fixtures/contracts/TickerRegistry.json';
-import { LOCAL_NETWORK_ID } from '../constants';
+import { LOCAL_NETWORK_ID, KOVAN_NETWORK_ID } from '../constants';
 
 const ORIGINAL_ENV = { ...process.env };
 
@@ -37,6 +37,22 @@ describe('constants', () => {
       expect(addresses[LOCAL_NETWORK_ID].TickerRegistry).toEqual(
         tickerRegistryArtifactAddress
       );
+    });
+
+    test('staging uses different addresses from production for kovan', () => {
+      process.env.DEPLOYMENT_STAGE = 'staging';
+      const stagingConstants = require('../constants');
+      const stagingAddresses =
+        stagingConstants.NETWORK_ADDRESSES[KOVAN_NETWORK_ID];
+
+      jest.resetModules();
+
+      process.env.DEPLOYMENT_STAGE = 'production';
+      const productionConstants = require('../constants');
+      const productionAddresses =
+        productionConstants.NETWORK_ADDRESSES[KOVAN_NETWORK_ID];
+
+      expect(productionAddresses).not.toEqual(stagingAddresses);
     });
   });
 

--- a/packages/polymath-shared/src/constants.js
+++ b/packages/polymath-shared/src/constants.js
@@ -1,6 +1,5 @@
 // @flow
 
-import PolyTokenArtifacts from './fixtures/contracts/PolyToken.json';
 import PolyTokenFaucetArtifacts from './fixtures/contracts/PolyTokenFaucet.json';
 import PolymathRegistryArtifacts from './fixtures/contracts/PolymathRegistry.json';
 import TickerRegistryArtifacts from './fixtures/contracts/TickerRegistry.json';
@@ -61,9 +60,24 @@ const localAddresses = {
       .address,
 };
 
+const kovanStagingPolyFaucetAddress =
+  '0x33c0c74675bb3e8fbf7d7510da998c3ef913e407';
+const kovanStagingAddresses = {
+  PolyTokenFaucet: kovanStagingPolyFaucetAddress,
+  PolyToken: kovanStagingPolyFaucetAddress,
+  PolymathRegistry: '0x9a987a1eee04c2784030347df6778e1a9170f467',
+  TickerRegistry: '0x6665a9bc33edc5839907f06c4c4586a4117aafb2',
+  ModuleRegistry: '0xf661fa176636c7b97d281bc802b0da8d43851ec4',
+  SecurityTokenRegistry: '0x7edd08ddc4763d6243cab427721d2afcca843579',
+  CappedSTOFactory: '0xdeacac8248723dbaf2bf6776f293228993e05a0e',
+  GeneralPermissionManagerFactory: '0xf97976bab461f354a06aa30132f56278c33c86bb',
+  CountTransferManagerFactory: '0xb36e11e8b01811610a04fccec25651566438109b',
+  PercentageTransferManagerFactory:
+    '0x25b7e309441e47c1892b56fa420bda02afdaa14f',
+};
+
 const kovanProductionPolyFaucetAddress =
   '0xb06d72a24df50d4e2cac133b320c5e7de3ef94cb';
-
 const kovanProductionAddresses = {
   PolyTokenFaucet: kovanProductionPolyFaucetAddress,
   PolyToken: kovanProductionPolyFaucetAddress,
@@ -79,13 +93,11 @@ const kovanProductionAddresses = {
 };
 
 export const _STAGING_ADDRESSES = {
-  // FIXME @RafaelVidaurre: Don't share production Kovan with staging Kovan
-  [KOVAN_NETWORK_ID]: kovanProductionAddresses,
+  [KOVAN_NETWORK_ID]: kovanStagingAddresses,
 };
 
 export const _LOCAL_ADDRESSES = {
-  // FIXME @RafaelVidaurre: Don't share production Kovan with staging Kovan
-  [KOVAN_NETWORK_ID]: kovanProductionAddresses,
+  [KOVAN_NETWORK_ID]: kovanStagingAddresses,
   [LOCAL_NETWORK_ID]: localAddresses,
 };
 


### PR DESCRIPTION
Uses different addresses for kovan on production vs kovan on staging

**Please make sure the following boxes are checked before submitting your Pull Request:**

- [X] I linked the issues related to this PR in its description (if any).
- [X] If this PR adds new code that is not going to change in the near future, it includes unit tests to cover it.

# This PR

- Adds new addresses for a staging version of the contracts on kovan (deployed already)
- Adds tests to ensure we never mistakenly paste some production address into staging

Notes: Local is using Staging Kovan addresses for now, we can deploy a separate version if we need one (which we probably will soon. But I'm guessing its gonna happen with 2.0)