### PR TITLE
Support local blockchain in staging offchain

### DIFF
--- a/packages/polymath-issuer/.env.local
+++ b/packages/polymath-issuer/.env.local
@@ -4,6 +4,8 @@
 # * REACT_APP_NETWORK_KOVAN_WS: Kovan node's websocket url
 # * REACT_APP_NETWORK_MAIN_WS: Mainnet node's websocket url
 # * REACT_APP_NETWORK_LOCAL_WS: Local blockchain network's url 
+# * REACT_APP_NETWORK_LOCALVM_WS: LocalVM blockchain network's url (used for
+#  cross-browser testing)
 # * REACT_APP_NODE_WS: Legacy env variable used to override websocket url to
 #  network.
 #  TODO @RafaelVidaurre: This is not defaulting to ganache on localhost right now since auth

--- a/packages/polymath-offchain/.env.local
+++ b/packages/polymath-offchain/.env.local
@@ -1,6 +1,7 @@
 #
 # Blockchain
 # ------------------------------------------------------------------------------
+# * WEB3_NETWORK_LOCALVM_WS: LOCAL VM URL used for cross-browser testing
 # * WEB3_NETWORK_LOCAL_WS: LOCAL URL for the web3 WebsocketProvider
 # * WEB3_NETWORK_KOVAN_WS: KOVAN URL for the web3 WebsocketProvider
 # * WEB3_NETWORK_MAINNET_WS: MAINNET URL for the web3 WebsocketProvider

--- a/packages/polymath-offchain/.env.local
+++ b/packages/polymath-offchain/.env.local
@@ -1,7 +1,8 @@
 #
 # Blockchain
 # ------------------------------------------------------------------------------
-# * WEB3_NETWORK_LOCALVM_WS: LOCAL VM URL used for cross-browser testing
+# * WEB3_NETWORK_LOCALVM_WS: LOCAL VM URL for the web3 WebSocketProvider (used
+#  for cross-browser testing)
 # * WEB3_NETWORK_LOCAL_WS: LOCAL URL for the web3 WebsocketProvider
 # * WEB3_NETWORK_KOVAN_WS: KOVAN URL for the web3 WebsocketProvider
 # * WEB3_NETWORK_MAINNET_WS: MAINNET URL for the web3 WebsocketProvider

--- a/packages/polymath-offchain/src/__tests__/constants.js
+++ b/packages/polymath-offchain/src/__tests__/constants.js
@@ -28,153 +28,381 @@ describe('Function: cleanEnvironment', () => {
 describe('Constants', () => {
   beforeEach(() => {
     jest.resetModules();
-    process.env = { ...ORIGINAL_ENV };
+    process.env = {
+      ...ORIGINAL_ENV,
+      WEB3_NETWORK_LOCAL_WS: 'ws://some.local.url',
+      WEB3_NETWORK_LOCALVM_WS: 'ws://some.localVM.url',
+      WEB3_NETWORK_KOVAN_WS: 'ws//some.kovan.url',
+      WEB3_NETWORK_MAINNET_WS: 'ws//some.mainnet.url',
+    };
   });
 
   test('throws error if both localVM and local network URLs are set', () => {
-    process.env.WEB3_NETWORK_LOCAL_WS = 'ws://some.url';
-    process.env.WEB3_NETWORK_LOCALVM_WS = 'ws://some.url';
-    expect(() => require('../constants.js')).toThrowError();
+    expect(() => require('../constants.js')).toThrow(
+      'Only one of WEB3_NETWORK_LOCAL_WS or WEB3_NETWORK_LOCALVM_WS must be set, not both'
+    );
   });
 
-  test('throws error when no local network URL has been set for local stage', () => {
+  test('throws error when neither local or localVM network URLs have been set for local stage', () => {
     process.env.DEPLOYMENT_STAGE = 'local';
     process.env.WEB3_NETWORK_LOCAL_WS = undefined;
-    expect(() => require('../constants.js')).toThrowError();
+    process.env.WEB3_NETWORK_LOCALVM_WS = undefined;
+    expect(() => require('../constants.js')).toThrow(
+      'Missing env variables: at least one of WEB3_NETWORK_LOCAL_WS or WEB3_NETWORK_LOCALVM_WS must be set'
+    );
   });
 
   test('throws error when no kovan network URL has been set for staging stage', () => {
     process.env.DEPLOYMENT_STAGE = 'staging';
+    process.env.WEB3_NETWORK_LOCALVM_WS = undefined;
     process.env.WEB3_NETWORK_KOVAN_WS = undefined;
-    expect(() => require('../constants.js')).toThrowError();
+    expect(() => require('../constants.js')).toThrow(
+      'Missing env variable WEB3_NETWORK_KOVAN_WS'
+    );
   });
 
   test('throws error when no kovan network URL has been set for production stage', () => {
     process.env.DEPLOYMENT_STAGE = 'production';
+    process.env.WEB3_NETWORK_LOCALVM_WS = undefined;
     process.env.WEB3_NETWORK_KOVAN_WS = undefined;
-    process.env.WEB3_NETWORK_MAINNET_WS = 'ws://some.url';
-    expect(() => require('../constants.js')).toThrowError();
+    expect(() => require('../constants.js')).toThrow(
+      'Missing env variable WEB3_NETWORK_KOVAN_WS'
+    );
   });
 
   test('throws error when no mainnet network URL has been set for production stage', () => {
     process.env.DEPLOYMENT_STAGE = 'production';
-    process.env.WEB3_NETWORK_KOVAN_WS = 'ws://some.url';
+    process.env.WEB3_NETWORK_LOCALVM_WS = undefined;
     process.env.WEB3_NETWORK_MAINNET_WS = undefined;
-    process.env.POLYMATH_REGISTRY_ADDRESS_KOVAN = '0x0';
-    expect(() => require('../constants.js')).toThrowError();
+    expect(() => require('../constants.js')).toThrow(
+      'Missing env variable WEB3_NETWORK_MAINNET_WS'
+    );
   });
 
-  const expectedLocalUrl = 'ws://some.local.url';
-  const expectedLocalVMUrl = 'ws://some.localVM.url';
-  const expectedKovanUrl = 'ws://some.kovan.url';
-  const expectedMainnetUrl = 'ws://some.mainnet.url';
+  const criticalRetries = 5;
+  const optionalRetries = 0;
+  const expectedLocalName = 'local';
+  const expectedLocalVMName = 'localVM';
+  const expectedKovanName = 'kovan';
+  const expectedMainnetName = 'mainnet';
 
   test('sets network params correctly when on local stage', () => {
     process.env.DEPLOYMENT_STAGE = 'local';
-    process.env.WEB3_NETWORK_LOCAL_WS = expectedLocalUrl;
-    process.env.WEB3_NETWORK_KOVAN_WS = expectedKovanUrl;
-    process.env.WEB3_NETWORK_MAINNET_WS = expectedMainnetUrl;
+    process.env.WEB3_NETWORK_LOCALVM_WS = undefined;
 
-    const { NETWORKS } = require('../constants.js');
+    const {
+      NETWORKS,
+      LOCAL_NETWORK_ID,
+      LOCALVM_NETWORK_ID,
+      KOVAN_NETWORK_ID,
+      MAINNET_NETWORK_ID,
+    } = require('../constants.js');
+
+    const {
+      WEB3_NETWORK_LOCAL_WS,
+      WEB3_NETWORK_KOVAN_WS,
+      WEB3_NETWORK_MAINNET_WS,
+    } = process.env;
 
     expect(NETWORKS).toEqual({
-      '15': {
-        name: 'local',
-        url: expectedLocalUrl,
+      [LOCAL_NETWORK_ID]: {
+        name: expectedLocalName,
+        url: WEB3_NETWORK_LOCAL_WS,
+        connect: true,
+        optional: false,
+        localNetwork: true,
+        maxRetries: criticalRetries,
+      },
+      [LOCALVM_NETWORK_ID]: {
+        name: expectedLocalVMName,
+        url: '',
+        connect: false,
+        optional: true,
+        localNetwork: true,
+        maxRetries: optionalRetries,
+      },
+      [KOVAN_NETWORK_ID]: {
+        name: expectedKovanName,
+        url: WEB3_NETWORK_KOVAN_WS,
+        connect: false,
+        optional: true,
+        localNetwork: false,
+        maxRetries: optionalRetries,
+      },
+      [MAINNET_NETWORK_ID]: {
+        name: expectedMainnetName,
+        url: WEB3_NETWORK_MAINNET_WS,
+        connect: false,
+        optional: true,
+        localNetwork: false,
+        maxRetries: optionalRetries,
       },
     });
   });
 
   test('sets network params correctly when on local stage if testing with VM', () => {
     process.env.DEPLOYMENT_STAGE = 'local';
-    process.env.WEB3_NETWORK_LOCAL_WS = '';
-    process.env.WEB3_NETWORK_LOCALVM_WS = expectedLocalVMUrl;
-    process.env.WEB3_NETWORK_KOVAN_WS = expectedKovanUrl;
-    process.env.WEB3_NETWORK_MAINNET_WS = expectedMainnetUrl;
+    process.env.WEB3_NETWORK_LOCAL_WS = undefined;
 
-    const { NETWORKS } = require('../constants.js');
+    const {
+      NETWORKS,
+      LOCAL_NETWORK_ID,
+      LOCALVM_NETWORK_ID,
+      KOVAN_NETWORK_ID,
+      MAINNET_NETWORK_ID,
+    } = require('../constants.js');
+
+    const {
+      WEB3_NETWORK_LOCALVM_WS,
+      WEB3_NETWORK_KOVAN_WS,
+      WEB3_NETWORK_MAINNET_WS,
+    } = process.env;
 
     expect(NETWORKS).toEqual({
-      '16': {
-        name: 'localVM',
-        url: expectedLocalVMUrl,
+      [LOCAL_NETWORK_ID]: {
+        name: expectedLocalName,
+        url: '',
+        connect: false,
+        optional: true,
+        localNetwork: true,
+        maxRetries: optionalRetries,
+      },
+      [LOCALVM_NETWORK_ID]: {
+        name: expectedLocalVMName,
+        url: WEB3_NETWORK_LOCALVM_WS,
+        connect: true,
+        optional: false,
+        localNetwork: true,
+        maxRetries: criticalRetries,
+      },
+      [KOVAN_NETWORK_ID]: {
+        name: expectedKovanName,
+        url: WEB3_NETWORK_KOVAN_WS,
+        connect: false,
+        optional: true,
+        localNetwork: false,
+        maxRetries: optionalRetries,
+      },
+      [MAINNET_NETWORK_ID]: {
+        name: expectedMainnetName,
+        url: WEB3_NETWORK_MAINNET_WS,
+        connect: false,
+        optional: true,
+        localNetwork: false,
+        maxRetries: optionalRetries,
       },
     });
   });
 
   test('sets network params correctly when on staging stage if no local network is specified', () => {
     process.env.DEPLOYMENT_STAGE = 'staging';
-    process.env.WEB3_NETWORK_LOCAL_WS = '';
-    process.env.WEB3_NETWORK_KOVAN_WS = expectedKovanUrl;
-    process.env.WEB3_NETWORK_MAINNET_WS = expectedMainnetUrl;
+    process.env.WEB3_NETWORK_LOCAL_WS = undefined;
+    process.env.WEB3_NETWORK_LOCALVM_WS = undefined;
 
-    const { NETWORKS } = require('../constants.js');
+    const {
+      NETWORKS,
+      LOCAL_NETWORK_ID,
+      LOCALVM_NETWORK_ID,
+      KOVAN_NETWORK_ID,
+      MAINNET_NETWORK_ID,
+    } = require('../constants.js');
+
+    const { WEB3_NETWORK_KOVAN_WS, WEB3_NETWORK_MAINNET_WS } = process.env;
 
     expect(NETWORKS).toEqual({
-      '42': {
-        name: 'kovan',
-        url: expectedKovanUrl,
+      [LOCAL_NETWORK_ID]: {
+        name: expectedLocalName,
+        url: '',
+        connect: false,
+        optional: true,
+        localNetwork: true,
+        maxRetries: optionalRetries,
+      },
+      [LOCALVM_NETWORK_ID]: {
+        name: expectedLocalVMName,
+        url: '',
+        connect: false,
+        optional: true,
+        localNetwork: true,
+        maxRetries: optionalRetries,
+      },
+      [KOVAN_NETWORK_ID]: {
+        name: expectedKovanName,
+        url: WEB3_NETWORK_KOVAN_WS,
+        connect: true,
+        optional: false,
+        localNetwork: false,
+        maxRetries: criticalRetries,
+      },
+      [MAINNET_NETWORK_ID]: {
+        name: expectedMainnetName,
+        url: WEB3_NETWORK_MAINNET_WS,
+        connect: false,
+        optional: true,
+        localNetwork: false,
+        maxRetries: optionalRetries,
       },
     });
   });
 
   test('sets network params correctly when on staging stage if a local network is specified', () => {
     process.env.DEPLOYMENT_STAGE = 'staging';
-    process.env.WEB3_NETWORK_LOCAL_WS = expectedLocalUrl;
-    process.env.WEB3_NETWORK_KOVAN_WS = expectedKovanUrl;
-    process.env.WEB3_NETWORK_MAINNET_WS = expectedMainnetUrl;
+    process.env.WEB3_NETWORK_LOCALVM_WS = undefined;
 
-    const { NETWORKS } = require('../constants.js');
+    const {
+      NETWORKS,
+      LOCAL_NETWORK_ID,
+      LOCALVM_NETWORK_ID,
+      KOVAN_NETWORK_ID,
+      MAINNET_NETWORK_ID,
+    } = require('../constants.js');
+
+    const {
+      WEB3_NETWORK_LOCAL_WS,
+      WEB3_NETWORK_KOVAN_WS,
+      WEB3_NETWORK_MAINNET_WS,
+    } = process.env;
 
     expect(NETWORKS).toEqual({
-      '15': {
-        name: 'local',
-        url: expectedLocalUrl,
+      [LOCAL_NETWORK_ID]: {
+        name: expectedLocalName,
+        url: WEB3_NETWORK_LOCAL_WS,
+        connect: true,
+        optional: true,
+        localNetwork: true,
+        maxRetries: optionalRetries,
       },
-      '42': {
-        name: 'kovan',
-        url: expectedKovanUrl,
+      [LOCALVM_NETWORK_ID]: {
+        name: expectedLocalVMName,
+        url: '',
+        connect: false,
+        optional: true,
+        localNetwork: true,
+        maxRetries: optionalRetries,
+      },
+      [KOVAN_NETWORK_ID]: {
+        name: expectedKovanName,
+        url: WEB3_NETWORK_KOVAN_WS,
+        connect: true,
+        optional: false,
+        localNetwork: false,
+        maxRetries: criticalRetries,
+      },
+      [MAINNET_NETWORK_ID]: {
+        name: expectedMainnetName,
+        url: WEB3_NETWORK_MAINNET_WS,
+        connect: false,
+        optional: true,
+        localNetwork: false,
+        maxRetries: optionalRetries,
       },
     });
   });
 
   test('sets network params correctly when on staging stage if a localVM network is specified', () => {
     process.env.DEPLOYMENT_STAGE = 'staging';
-    process.env.WEB3_NETWORK_LOCAL_WS = '';
-    process.env.WEB3_NETWORK_LOCALVM_WS = expectedLocalVMUrl;
-    process.env.WEB3_NETWORK_KOVAN_WS = expectedKovanUrl;
-    process.env.WEB3_NETWORK_MAINNET_WS = expectedMainnetUrl;
+    process.env.WEB3_NETWORK_LOCAL_WS = undefined;
 
-    const { NETWORKS } = require('../constants.js');
+    const {
+      NETWORKS,
+      LOCAL_NETWORK_ID,
+      LOCALVM_NETWORK_ID,
+      KOVAN_NETWORK_ID,
+      MAINNET_NETWORK_ID,
+    } = require('../constants.js');
+
+    const {
+      WEB3_NETWORK_LOCALVM_WS,
+      WEB3_NETWORK_KOVAN_WS,
+      WEB3_NETWORK_MAINNET_WS,
+    } = process.env;
 
     expect(NETWORKS).toEqual({
-      '16': {
-        name: 'localVM',
-        url: expectedLocalVMUrl,
+      [LOCAL_NETWORK_ID]: {
+        name: expectedLocalName,
+        url: '',
+        connect: false,
+        optional: true,
+        localNetwork: true,
+        maxRetries: optionalRetries,
       },
-      '42': {
-        name: 'kovan',
-        url: expectedKovanUrl,
+      [LOCALVM_NETWORK_ID]: {
+        name: expectedLocalVMName,
+        url: WEB3_NETWORK_LOCALVM_WS,
+        connect: true,
+        optional: true,
+        localNetwork: true,
+        maxRetries: optionalRetries,
+      },
+      [KOVAN_NETWORK_ID]: {
+        name: expectedKovanName,
+        url: WEB3_NETWORK_KOVAN_WS,
+        connect: true,
+        optional: false,
+        localNetwork: false,
+        maxRetries: criticalRetries,
+      },
+      [MAINNET_NETWORK_ID]: {
+        name: expectedMainnetName,
+        url: WEB3_NETWORK_MAINNET_WS,
+        connect: false,
+        optional: true,
+        localNetwork: false,
+        maxRetries: optionalRetries,
       },
     });
   });
 
   test('sets network params correctly when on production stage', () => {
     process.env.DEPLOYMENT_STAGE = 'production';
-    process.env.WEB3_NETWORK_LOCAL_WS = expectedLocalUrl;
-    process.env.WEB3_NETWORK_KOVAN_WS = expectedKovanUrl;
-    process.env.WEB3_NETWORK_MAINNET_WS = expectedMainnetUrl;
+    process.env.WEB3_NETWORK_LOCALVM_WS = undefined;
 
-    const { NETWORKS } = require('../constants.js');
+    const {
+      NETWORKS,
+      LOCAL_NETWORK_ID,
+      LOCALVM_NETWORK_ID,
+      KOVAN_NETWORK_ID,
+      MAINNET_NETWORK_ID,
+    } = require('../constants.js');
+
+    const {
+      WEB3_NETWORK_LOCAL_WS,
+      WEB3_NETWORK_KOVAN_WS,
+      WEB3_NETWORK_MAINNET_WS,
+    } = process.env;
 
     expect(NETWORKS).toEqual({
-      '42': {
-        name: 'kovan',
-        url: expectedKovanUrl,
+      [LOCAL_NETWORK_ID]: {
+        name: expectedLocalName,
+        url: WEB3_NETWORK_LOCAL_WS,
+        connect: false,
+        optional: true,
+        localNetwork: true,
+        maxRetries: optionalRetries,
       },
-      '1': {
-        name: 'mainnet',
-        url: expectedMainnetUrl,
+      [LOCALVM_NETWORK_ID]: {
+        name: expectedLocalVMName,
+        url: '',
+        connect: false,
+        optional: true,
+        localNetwork: true,
+        maxRetries: optionalRetries,
+      },
+      [KOVAN_NETWORK_ID]: {
+        name: expectedKovanName,
+        url: WEB3_NETWORK_KOVAN_WS,
+        connect: true,
+        optional: false,
+        localNetwork: false,
+        maxRetries: criticalRetries,
+      },
+      [MAINNET_NETWORK_ID]: {
+        name: expectedMainnetName,
+        url: WEB3_NETWORK_MAINNET_WS,
+        connect: true,
+        optional: false,
+        localNetwork: false,
+        maxRetries: criticalRetries,
       },
     });
   });

--- a/packages/polymath-offchain/src/__tests__/constants.js
+++ b/packages/polymath-offchain/src/__tests__/constants.js
@@ -31,6 +31,12 @@ describe('Constants', () => {
     process.env = { ...ORIGINAL_ENV };
   });
 
+  test('throws error if both localVM and local network URLs are set', () => {
+    process.env.WEB3_NETWORK_LOCAL_WS = 'ws://some.url';
+    process.env.WEB3_NETWORK_LOCALVM_WS = 'ws://some.url';
+    expect(() => require('../constants.js')).toThrowError();
+  });
+
   test('throws error when no local network URL has been set for local stage', () => {
     process.env.DEPLOYMENT_STAGE = 'local';
     process.env.WEB3_NETWORK_LOCAL_WS = undefined;
@@ -54,10 +60,12 @@ describe('Constants', () => {
     process.env.DEPLOYMENT_STAGE = 'production';
     process.env.WEB3_NETWORK_KOVAN_WS = 'ws://some.url';
     process.env.WEB3_NETWORK_MAINNET_WS = undefined;
+    process.env.POLYMATH_REGISTRY_ADDRESS_KOVAN = '0x0';
     expect(() => require('../constants.js')).toThrowError();
   });
 
   const expectedLocalUrl = 'ws://some.local.url';
+  const expectedLocalVMUrl = 'ws://some.localVM.url';
   const expectedKovanUrl = 'ws://some.kovan.url';
   const expectedMainnetUrl = 'ws://some.mainnet.url';
 
@@ -77,7 +85,40 @@ describe('Constants', () => {
     });
   });
 
-  test('sets network params correctly when on staging stage', () => {
+  test('sets network params correctly when on local stage if testing with VM', () => {
+    process.env.DEPLOYMENT_STAGE = 'local';
+    process.env.WEB3_NETWORK_LOCAL_WS = '';
+    process.env.WEB3_NETWORK_LOCALVM_WS = expectedLocalVMUrl;
+    process.env.WEB3_NETWORK_KOVAN_WS = expectedKovanUrl;
+    process.env.WEB3_NETWORK_MAINNET_WS = expectedMainnetUrl;
+
+    const { NETWORKS } = require('../constants.js');
+
+    expect(NETWORKS).toEqual({
+      '16': {
+        name: 'localVM',
+        url: expectedLocalVMUrl,
+      },
+    });
+  });
+
+  test('sets network params correctly when on staging stage if no local network is specified', () => {
+    process.env.DEPLOYMENT_STAGE = 'staging';
+    process.env.WEB3_NETWORK_LOCAL_WS = '';
+    process.env.WEB3_NETWORK_KOVAN_WS = expectedKovanUrl;
+    process.env.WEB3_NETWORK_MAINNET_WS = expectedMainnetUrl;
+
+    const { NETWORKS } = require('../constants.js');
+
+    expect(NETWORKS).toEqual({
+      '42': {
+        name: 'kovan',
+        url: expectedKovanUrl,
+      },
+    });
+  });
+
+  test('sets network params correctly when on staging stage if a local network is specified', () => {
     process.env.DEPLOYMENT_STAGE = 'staging';
     process.env.WEB3_NETWORK_LOCAL_WS = expectedLocalUrl;
     process.env.WEB3_NETWORK_KOVAN_WS = expectedKovanUrl;
@@ -86,6 +127,31 @@ describe('Constants', () => {
     const { NETWORKS } = require('../constants.js');
 
     expect(NETWORKS).toEqual({
+      '15': {
+        name: 'local',
+        url: expectedLocalUrl,
+      },
+      '42': {
+        name: 'kovan',
+        url: expectedKovanUrl,
+      },
+    });
+  });
+
+  test('sets network params correctly when on staging stage if a localVM network is specified', () => {
+    process.env.DEPLOYMENT_STAGE = 'staging';
+    process.env.WEB3_NETWORK_LOCAL_WS = '';
+    process.env.WEB3_NETWORK_LOCALVM_WS = expectedLocalVMUrl;
+    process.env.WEB3_NETWORK_KOVAN_WS = expectedKovanUrl;
+    process.env.WEB3_NETWORK_MAINNET_WS = expectedMainnetUrl;
+
+    const { NETWORKS } = require('../constants.js');
+
+    expect(NETWORKS).toEqual({
+      '16': {
+        name: 'localVM',
+        url: expectedLocalVMUrl,
+      },
       '42': {
         name: 'kovan',
         url: expectedKovanUrl,

--- a/packages/polymath-offchain/src/constants.js
+++ b/packages/polymath-offchain/src/constants.js
@@ -127,7 +127,7 @@ export const NETWORKS: {
  */
 if (DEPLOYMENT_STAGE !== 'local') {
   if (!WEB3_NETWORK_KOVAN_WS) {
-    throw new Error(`Missing env variable WEB3_NETWORK_KOVAN_WS`);
+    throw new Error('Missing env variable WEB3_NETWORK_KOVAN_WS');
   }
 
   NETWORKS[KOVAN_NETWORK_ID].connect = true;

--- a/packages/polymath-offchain/src/startup/__tests__/setupWeb3.js
+++ b/packages/polymath-offchain/src/startup/__tests__/setupWeb3.js
@@ -99,6 +99,11 @@ const contractMock = jest.fn().mockImplementation(() => {
     },
   };
 });
+const clientMock = {
+  config: {
+    closeTimeout: 5000,
+  },
+};
 const connectionCloseMock = jest.fn();
 const getIdMock = jest.fn().mockImplementation(() => 15);
 const websocketProviderMock = jest.fn().mockImplementation(() => {
@@ -107,6 +112,7 @@ const websocketProviderMock = jest.fn().mockImplementation(() => {
     connection: {
       CLOSED: 3,
       readyState: 0,
+      _client: clientMock,
     },
   };
 });
@@ -130,6 +136,7 @@ const constructorMock = jest.fn().mockImplementation(() => {
         CLOSING: 2,
         CLOSED: 3,
         readyState: 3,
+        _client: clientMock,
       },
     },
   };
@@ -173,27 +180,34 @@ describe('Function: connectWeb3', () => {
         connection: {
           CLOSED: 3,
           readyState: 3,
+          _client: clientMock,
         },
       };
     });
 
-    const connectionSuccessful = await connectWeb3(validNetworkId);
+    const connectPromise = connectWeb3(validNetworkId);
+
+    jest.advanceTimersByTime(5000);
+
+    const connectionSuccessful = await connectPromise;
 
     expect(websocketProviderMock).toHaveBeenCalledWith(
       NETWORKS[validNetworkId].url
     );
-    expect(socketEventListenerMock).toHaveBeenCalledTimes(3);
-    expect(socketEventListenerMock.mock.calls[0][0]).toBe('error');
-    expect(socketEventListenerMock.mock.calls[1][0]).toBe('close');
-    expect(socketEventListenerMock.mock.calls[2][0]).toBe('end');
+    expect(socketEventListenerMock).toHaveBeenCalledTimes(0);
     expect(connectionSuccessful).toBe(false);
   });
 
   test('connects to the provider and adds socket listeners', async () => {
     const connectWeb3 = require('../setupWeb3').default;
 
-    await connectWeb3(validNetworkId);
+    const connectPromise = connectWeb3(validNetworkId);
 
+    jest.advanceTimersByTime(5000);
+
+    const connectionSuccessful = await connectPromise;
+
+    expect(connectionSuccessful).toBe(true);
     expect(websocketProviderMock).toHaveBeenCalledWith(
       NETWORKS[validNetworkId].url
     );
@@ -208,10 +222,15 @@ describe('Function: connectWeb3', () => {
 
     const connectWeb3 = require('../setupWeb3').default;
 
-    await connectWeb3(validNetworkId);
+    const connectPromise = connectWeb3(validNetworkId);
+
+    jest.advanceTimersByTime(5000);
+
+    const connectionSuccessful = await connectPromise;
 
     jest.advanceTimersByTime(20000);
 
+    expect(connectionSuccessful).toBe(true);
     expect(isListeningMock).toHaveBeenCalledTimes(4);
   });
 
@@ -229,10 +248,15 @@ describe('Function: connectWeb3', () => {
       .mockImplementationOnce(eventListener)
       .mockImplementationOnce(eventListener);
 
-    const connectWeb3 = require('../setupWeb3').default;
+    let connectWeb3 = require('../setupWeb3').default;
 
-    await connectWeb3(validNetworkId);
+    let connectPromise = connectWeb3(validNetworkId);
 
+    jest.advanceTimersByTime(5000);
+
+    let connectionSuccessful = await connectPromise;
+
+    expect(connectionSuccessful).toBe(true);
     expect(logger.error).toHaveBeenCalledTimes(1);
     expect(logger.info).toHaveBeenCalledWith(
       `[SETUP] Reconnecting LOCAL socket after error...`
@@ -254,7 +278,13 @@ describe('Function: connectWeb3', () => {
       .mockImplementationOnce(eventListener)
       .mockImplementationOnce(eventListener);
 
-    await connectWeb3(validNetworkId);
+    connectPromise = connectWeb3(validNetworkId);
+
+    jest.advanceTimersByTime(5000);
+
+    connectionSuccessful = await connectPromise;
+
+    expect(connectionSuccessful).toBe(true);
 
     expect(logger.error).not.toHaveBeenCalled();
     expect(logger.info).toHaveBeenCalledWith(
@@ -277,8 +307,13 @@ describe('Function: connectWeb3', () => {
 
     const connectWeb3 = require('../setupWeb3').default;
 
-    await connectWeb3(validNetworkId);
+    const connectPromise = connectWeb3(validNetworkId);
 
+    jest.advanceTimersByTime(5000);
+
+    const connectionSuccessful = await connectPromise;
+
+    expect(connectionSuccessful).toBe(true);
     expect(logger.info).toHaveBeenCalledWith(
       `[SETUP] Reconnecting LOCAL socket after close...`
     );
@@ -299,17 +334,90 @@ describe('Function: connectWeb3', () => {
 
     const connectWeb3 = require('../setupWeb3').default;
 
-    await connectWeb3(validNetworkId);
+    const connectPromise = connectWeb3(validNetworkId);
 
+    jest.advanceTimersByTime(5000);
+
+    const connectionSuccessful = await connectPromise;
+
+    expect(connectionSuccessful).toBe(true);
     expect(logger.info).toHaveBeenCalledWith(
       `[SETUP] Reconnecting LOCAL socket after end...`
     );
   });
 
-  test('logs blockchain listener errors', () => {
+  test('logs blockchain listener errors', async () => {
+    const expectedError = new Error('Something went wrong');
     contractMock.mockImplementationOnce(() => {
-      throw new Error('Something went wrong');
+      throw expectedError;
     });
+
+    const connectWeb3 = require('../setupWeb3').default;
+
+    const connectPromise = connectWeb3(validNetworkId);
+
+    jest.advanceTimersByTime(5000);
+
+    const connectionSuccessful = await connectPromise;
+
+    expect(connectionSuccessful).toBe(true);
+    expect(logger.error).toHaveBeenCalledWith(
+      expectedError.message,
+      expectedError
+    );
+  });
+});
+
+describe('Function: reconnect', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.clearAllTimers();
+  });
+
+  const validNetworkId = '15';
+
+  test('retries connection if provider is null', async () => {
+    websocketProviderMock
+      .mockImplementationOnce(() => {
+        return {
+          on: () => null,
+          connection: {
+            CLOSED: 3,
+            readyState: 3,
+            _client: clientMock,
+          },
+        };
+      })
+      .mockImplementationOnce(() => {
+        return {
+          on: () => null,
+          connection: {
+            CLOSED: 3,
+            readyState: 0,
+            _client: clientMock,
+          },
+        };
+      });
+
+    const reconnect = require('../setupWeb3').reconnect;
+
+    const reconnecting = reconnect(validNetworkId);
+
+    /**
+      NOTE @monitz87: This is needed because of how jest timer mocks
+      interact with promises (see https://stackoverflow.com/a/52196951)
+     */
+    jest.advanceTimersByTime(5000);
+    await Promise.resolve();
+    jest.advanceTimersByTime(5000);
+    await Promise.resolve();
+    jest.advanceTimersByTime(5000);
+
+    await reconnecting;
+
+    expect(logger.info).toHaveBeenCalledWith(
+      `[SETUP] Network LOCAL not found. Retrying connection...`
+    );
   });
 });
 
@@ -343,7 +451,11 @@ describe('Function: keepAlive', () => {
 
     const client = new Web3();
 
-    await keepAlive(client, validNetworkId);
+    const keepingAlive = keepAlive(client, validNetworkId);
+
+    jest.advanceTimersByTime(5000);
+
+    await keepingAlive;
 
     expect(clearInterval).toHaveBeenCalledTimes(1);
     expect(logger.info).toHaveBeenCalledWith(
@@ -370,6 +482,7 @@ describe('Function: keepAlive', () => {
             CLOSING: 2,
             CLOSED: 3,
             readyState: 0,
+            _client: clientMock,
           },
         },
       };

--- a/packages/polymath-offchain/src/startup/index.js
+++ b/packages/polymath-offchain/src/startup/index.js
@@ -11,9 +11,13 @@ import './setupMailing';
 import connectWeb3 from './setupWeb3';
 
 (async () => {
-  const { '15': local, '42': kovan, '1': mainnet } = NETWORKS;
+  const { '15': local, '16': localVM, '42': kovan, '1': mainnet } = NETWORKS;
   if (local) {
     await connectWeb3('15');
+  }
+
+  if (localVM) {
+    await connectWeb3('16');
   }
 
   if (kovan) {

--- a/packages/polymath-offchain/src/startup/setupWeb3.js
+++ b/packages/polymath-offchain/src/startup/setupWeb3.js
@@ -99,7 +99,6 @@ const newProvider = async (networkId: string) => {
     new Promise(resolve => {
       setTimeout(resolve, connection._client.config.closeTimeout);
     });
-
   await waitForHandshakeTimeout();
   if (connection.readyState === connection.CLOSED) {
     return null;
@@ -560,7 +559,7 @@ const followUpConnection = async (networkId: string, provider) => {
 
   @param {string} networkId id of the network to which we want to connect a client
  */
-const reconnect = async (networkId: string) => {
+export const reconnect = async (networkId: string) => {
   let provider;
 
   for (;;) {

--- a/packages/polymath-offchain/src/startup/setupWeb3.js
+++ b/packages/polymath-offchain/src/startup/setupWeb3.js
@@ -16,6 +16,7 @@ import CappedSTOArtifact from '@polymathnetwork/shared/fixtures/contracts/Capped
 
 // TODO @monitz87: remake this when we rework polymath-js
 const web3Clients = {};
+const heartbeatIntervalIds = {};
 
 /**
   Get the corresponding Security Token contract
@@ -75,7 +76,7 @@ const getSTRContract = async (networkId: string) => {
 
 /**
   Initializes and configures the WebsocketProvider
-  for the web3, setting listeners to reconnect on error.
+  for the web3 client, setting listeners to reconnect when the connection fails.
 
   @param {string} networkId id of the network for which we want the provider
 
@@ -84,11 +85,25 @@ const getSTRContract = async (networkId: string) => {
   which doesn't reconnect sockets nor re-subscribes to events when the
   socket connection is closed
  */
-const newProvider = (networkId: string) => {
+const newProvider = async (networkId: string) => {
   const { name, url } = NETWORKS[networkId];
   const networkName = name.toUpperCase();
 
   const provider = new Web3.providers.WebsocketProvider(url);
+  const connection = provider.connection;
+
+  /**
+    Check if the connection is successful
+   */
+  const waitForHandshakeTimeout = () =>
+    new Promise(resolve => {
+      setTimeout(resolve, connection._client.config.closeTimeout);
+    });
+
+  await waitForHandshakeTimeout();
+  if (connection.readyState === connection.CLOSED) {
+    return null;
+  }
 
   /**
     Reconnect when socket connection errors or ends
@@ -99,15 +114,18 @@ const newProvider = (networkId: string) => {
     }
 
     logger.info(`[SETUP] Reconnecting ${networkName} socket after error...`);
-    connectWeb3(networkId);
+    clearInterval(heartbeatIntervalIds[networkId]);
+    reconnect(networkId);
   });
   provider.on('close', () => {
     logger.info(`[SETUP] Reconnecting ${networkName} socket after close...`);
-    connectWeb3(networkId);
+    clearInterval(heartbeatIntervalIds[networkId]);
+    reconnect(networkId);
   });
   provider.on('end', () => {
     logger.info(`[SETUP] Reconnecting ${networkName} socket after end...`);
-    connectWeb3(networkId);
+    clearInterval(heartbeatIntervalIds[networkId]);
+    reconnect(networkId);
   });
 
   return provider;
@@ -463,8 +481,6 @@ const setupListeners = async (networkId: string) => {
   await addSTOListeners(networkId);
 };
 
-const heartbeatIntervalIds = {};
-
 /**
   Ping the socket. If there is something wrong with the conection,
   we kill the heartbeat and reset the web3 client and all the listeners
@@ -499,7 +515,7 @@ export const keepAlive = async (client: Object, networkId: string) => {
       )
     ) {
       logger.info(`[SETUP] Reconnecting ${networkName} socket after close...`);
-      await connectWeb3(networkId);
+      await reconnect(networkId);
     }
   }
 };
@@ -518,12 +534,13 @@ const simulateHeartbeat = (networkId: string) => {
 };
 
 /**
-  Connects a web3 client to a new provider in the chosen network and starts all the event listeners
+  Sets up heartbeat and listeners
 
   @param {string} networkId id of the network to which we want to connect a client
+  @param {Object} provider Web3 WebsocketProvider instance
  */
-const connectWeb3 = async (networkId: string) => {
-  web3Clients[networkId] = new Web3(newProvider(networkId));
+const followUpConnection = async (networkId: string, provider) => {
+  web3Clients[networkId] = new Web3(provider);
 
   simulateHeartbeat(networkId);
 
@@ -532,6 +549,55 @@ const connectWeb3 = async (networkId: string) => {
   } catch (error) {
     logger.error(error.message, error);
   }
+};
+
+/**
+  Reconnects the corresponding web3 client after a connection closes. Retries indefinitely
+  if the provider cannnot connect
+
+  TODO @monitz87: add a retry limit to this function that takes into consideration
+  if the network is optional to decide whether to just stop reconnecting or exit the app
+
+  @param {string} networkId id of the network to which we want to connect a client
+ */
+const reconnect = async (networkId: string) => {
+  let provider;
+
+  for (;;) {
+    provider = await newProvider(networkId);
+    if (provider) {
+      break;
+    }
+
+    logger.info(
+      `[SETUP] Network ${NETWORKS[
+        networkId
+      ].name.toUpperCase()} not found. Retrying connection...`
+    );
+  }
+
+  await followUpConnection(networkId, provider);
+
+  return true;
+};
+
+/**
+  Connects a web3 client to a new provider in the chosen network and starts all the event listeners
+
+  @param {string} networkId id of the network to which we want to connect a client
+
+  @returns {boolean} false if the network is unavailable, true if the connection was succesful
+ */
+const connectWeb3 = async (networkId: string) => {
+  const provider = await newProvider(networkId);
+
+  if (provider === null) {
+    return false;
+  }
+
+  await followUpConnection(networkId, provider);
+
+  return true;
 };
 
 export default connectWeb3;

--- a/packages/polymath-ui/src/components/EthNetworkWrapper/actions.js
+++ b/packages/polymath-ui/src/components/EthNetworkWrapper/actions.js
@@ -2,7 +2,7 @@
 
 import Web3 from 'web3';
 
-import getNetwork from './networks';
+import getNetwork, { NETWORK_LOCAL, NETWORK_LOCALVM } from './networks';
 import type { ExtractReturn } from './helpers';
 
 export type NetworkParams = {|
@@ -12,10 +12,6 @@ export type NetworkParams = {|
   web3: Web3,
   web3WS: Web3,
 |};
-
-// FIXME @RafaelVidaurre: This shouldn't be the right way to do it, but
-// this has to be here for now
-const HARDCODED_NETWORK_ID = 15;
 
 export const CONNECTED = 'polymath-auth/CONNECTED';
 const connected = (params: NetworkParams) => ({ type: CONNECTED, params });
@@ -43,9 +39,12 @@ export const init = (networks: Array<string>) => async (dispatch: Function) => {
       web3.setProvider(window.web3.currentProvider);
       id = await web3.eth.net.getId();
     }
-    // TODO @RafaelVidaurre: Make this code work with polymath in localhost
-    const isLocalhost = Number(id) === HARDCODED_NETWORK_ID || id === undefined;
-    const network = getNetwork(!isLocalhost ? id : undefined);
+
+    const isLocalhost =
+      Number(id) === NETWORK_LOCAL ||
+      Number(id) === NETWORK_LOCALVM ||
+      id === undefined;
+    const network = getNetwork(id);
 
     if (
       network === undefined ||

--- a/packages/polymath-ui/src/components/EthNetworkWrapper/networks.js
+++ b/packages/polymath-ui/src/components/EthNetworkWrapper/networks.js
@@ -9,8 +9,10 @@ export const NETWORK_MAIN = '1';
 export const NETWORK_ROPSTEN = '3';
 export const NETWORK_RINKEBY = '4';
 export const NETWORK_KOVAN = '42';
+export const NETWORK_LOCAL = '15';
+export const NETWORK_LOCALVM = '16';
 
-export default (id: string = 'local'): Network =>
+export default (id: string = NETWORK_LOCAL): Network =>
   ({
     [NETWORK_MAIN]: {
       name: 'Mainnet',
@@ -28,8 +30,12 @@ export default (id: string = 'local'): Network =>
       name: 'Kovan Testnet',
       url: process.env.REACT_APP_NETWORK_KOVAN_WS,
     },
-    local: {
+    [NETWORK_LOCAL]: {
       name: 'Localhost',
       url: process.env.REACT_APP_NETWORK_LOCAL_WS,
+    },
+    [NETWORK_LOCALVM]: {
+      name: 'LocalVM',
+      url: process.env.REACT_APP_NETWORK_LOCALVM_WS,
     },
   }[id]);


### PR DESCRIPTION
**Please make sure the following boxes are checked before submitting your Pull Request:**

- [x] I linked the issues related to this PR in its description (if any).
- [x] If this PR adds new code that is not going to change in the near future, it includes unit tests to cover it.

This PR adds support for local blockchains in offchain staging for testing purposes. It also reworks the offchain websocket reconnection logic. 

Offchain now differentiates between mandatory and optional networks depending on deployment stage. Mandatory networks retry the initial connection attempt on setup 5 times and optional networks don't retry (`CRITICAL_RETRIES = 5` vs `OPTIONAL_RETRIES = 0` defined in `constants.js`). When an initial connection attempt surpasses the retry limit, it will throw an error and exit (mandatory network) or simply log a warning (optional network). Once the initial connection has been established, if something happens to the websocket later, it will keep trying to recconect ad infinitum.
