### PR TITLE
Use websocket provider to fetch balance

### DIFF
--- a/packages/polymath-js/src/contracts/PolyToken.js
+++ b/packages/polymath-js/src/contracts/PolyToken.js
@@ -26,7 +26,9 @@ export class PolyToken extends Contract {
   }
 
   async balanceOf(account: Address): Promise<BigNumber> {
-    return this.removeDecimals(await this._methods.balanceOf(account).call());
+    return this.removeDecimals(
+      await this._contractWS.methods.balanceOf(account).call()
+    );
   }
 
   async myBalance(): Promise<BigNumber> {


### PR DESCRIPTION
The metamask provider has caching issues and sometimes returns stale data when querying the blockchain, this caused a bug when using the local blockchain that didn't update the issuer's balance after certain transactions.

**Please make sure the following boxes are checked before submitting your Pull Request:**

- [x] I linked the issues related to this PR in its description (if any).
- [x] If this PR adds new code that is not going to change in the near future, it includes unit tests to cover it.
