### PR TITLE
build(offchain): add src module resolver override for tests

### DIFF
--- a/packages/polymath-offchain/.babelrc.js
+++ b/packages/polymath-offchain/.babelrc.js
@@ -8,4 +8,9 @@ module.exports = {
     '@babel/plugin-transform-regenerator',
     moduleResolver('build'),
   ],
+  env: {
+    test: {
+      plugins: [moduleResolver('src')],
+    },
+  },
 };


### PR DESCRIPTION
**Please make sure the following boxes are checked before submitting your Pull Request:**

- [x] I linked the issues related to this PR in its description (if any).
- [x] If this PR adds new code that is not going to change in the near future, it includes unit tests to cover it.

This PR addresses unit tests failing in offchain if shared was not built previously. The babel config was resolving all root imports to `<package>/build` in offchain, even when testing (which shouldn't need other packages to be built).