### PR TITLE
fix: attempt to fix 404 error on providers page

### DIFF
--- a/packages/polymath-issuer/src/components/Dashboard.js
+++ b/packages/polymath-issuer/src/components/Dashboard.js
@@ -69,6 +69,7 @@ class Dashboard extends Component<Props> {
 
     if (!isTokenFetched) {
       // TODO @bshevchenko: why is this here?
+      // NOTE @monitz87: if you don't know, how do you expect us to?
       return <span />;
     }
     // $FlowFixMe

--- a/packages/polymath-js/src/contracts/TickerRegistry.js
+++ b/packages/polymath-js/src/contracts/TickerRegistry.js
@@ -42,7 +42,7 @@ class TickerRegistry extends Contract {
 
   async getDetails(symbol: string, txHash?: string): Promise<?SymbolDetails> {
     let [owner, timestamp, name, swarmHash, status] = this._toArray(
-      await this._methods.getDetails(symbol).call()
+      await this._contractWS.methods.getDetails(symbol).call()
     );
     if (this._isEmptyAddress(owner)) {
       return null;


### PR DESCRIPTION
**Please make sure the following boxes are checked before submitting your Pull Request:**

- [x] I linked the issues related to this PR in its description (if any).
- [x] If this PR adds new code that is not going to change in the near future, it includes unit tests to cover it.

This fix isn't definitive. The problem is that when fetching the token while loading the providers page, sometimes the token doesn't exist, and sometimes it's simply not found in the blockchain at the moment of fetching. The second **SHOULD** never happen, since we only navigate naturally to the providers page after the transactions have been completed. This leads me to believe the issue is with the metamask provider and its ridiculous caching strategies. The proposed fix uses the web3 websocket provider to fetch the token details, but it's not 100% reliable since I can't reproduce the bug. The definitive fix would be to use the upcoming middleware to store registered tickers off-chain, so then if the fetch fails for a ticker that we know has been registered, we can report this error in the UI as a problem with the blockchain, or simply retry the fetch a couple of times until it works and THEN report the error. Right now we have no surefire way of differentiating between a nonexistent ticker and a failed fetch of an existing one.