### PR TITLE
fix(ui): set account and network polling interval to 1 second

### DIFF
--- a/packages/polymath-ui/src/components/EthNetworkWrapper/actions.js
+++ b/packages/polymath-ui/src/components/EthNetworkWrapper/actions.js
@@ -74,7 +74,7 @@ export const init = (networks: Array<string>) => async (dispatch: Function) => {
             window.location.reload();
           }
         });
-      }, 100);
+      }, 1000);
     }
     if (!account) {
       throw new Error(ERROR_LOCKED);


### PR DESCRIPTION
**Please make sure the following boxes are checked before submitting your Pull Request:**

- [x] I linked the issues related to this PR in its description (if any).
- [x] If this PR adds new code that is not going to change in the near future, it includes unit tests to cover it.

The dApps need to poll the current node through the provider to check for account/network changes in order to reload. Metamask suggested polling the node every 100ms. This, of course, is utterly insane. Some versions of chrome are sensible enough to throttle this insanity, but firefox received the full brunt of this onslaught of requests and produced weird behavior (even causing errors and crashes in ganache-cli). I suspect this might have been causing some other issues as well. I changed the polling interval to 1 second (which may be slower to detect a network or account change but at least it won't crash the user's browser). This fixes erratic behavior in firefox and possibly other performance/network issues.