### PR TITLE
fix(ui): fix display value of percentage input when empty

### DIFF
--- a/packages/polymath-ui/src/components/inputs/PercentageInput/index.js
+++ b/packages/polymath-ui/src/components/inputs/PercentageInput/index.js
@@ -56,7 +56,7 @@ export default class PercentageInput extends Component {
       ...otherProps
     } = this.props;
 
-    const formattedValue = typeof value === 'number' ? value * 100 : '';
+    const formattedValue = !isNaN(value) ? value * 100 : '';
 
     return (
       <StyledBaseInput


### PR DESCRIPTION
**Please make sure the following boxes are checked before submitting your Pull Request:**

- [x] I linked the issues related to this PR in its description (if any).
- [x] If this PR adds new code that is not going to change in the near future, it includes unit tests to cover it.

This PR fixes empty values being shown as NaN in percentage inputs
