### PR TITLE
fix(issuer): redirect to /ticker on signin fail

### DIFF
--- a/packages/polymath-issuer/src/components/App.js
+++ b/packages/polymath-issuer/src/components/App.js
@@ -80,6 +80,13 @@ class App extends Component<Props> {
     this.props.signIn();
   }
 
+  onAuthFail() {
+    // Make sure user is on the ticker page if he doesn't have an account yet
+    if (this.props.location.pathname !== '/ticker') {
+      this.props.history.push('/ticker');
+    }
+  }
+
   render() {
     const { ticker, isFetching, route } = this.props;
 
@@ -91,7 +98,9 @@ class App extends Component<Props> {
         <TxModal />
         <EnterPINModal />
         <ConfirmModal />
-        <AuthWrapper>{renderRoutes(route.routes)}</AuthWrapper>
+        <AuthWrapper onFail={this.onAuthFail.bind(this)}>
+          {renderRoutes(route.routes)}
+        </AuthWrapper>
         <Footer />
       </Fragment>
     );

--- a/packages/polymath-issuer/src/components/App.js
+++ b/packages/polymath-issuer/src/components/App.js
@@ -80,12 +80,12 @@ class App extends Component<Props> {
     this.props.signIn();
   }
 
-  onAuthFail() {
+  onAuthFail = () => {
     // Make sure user is on the ticker page if he doesn't have an account yet
     if (this.props.location.pathname !== '/ticker') {
       this.props.history.push('/ticker');
     }
-  }
+  };
 
   render() {
     const { ticker, isFetching, route } = this.props;
@@ -98,7 +98,7 @@ class App extends Component<Props> {
         <TxModal />
         <EnterPINModal />
         <ConfirmModal />
-        <AuthWrapper onFail={this.onAuthFail.bind(this)}>
+        <AuthWrapper onFail={this.onAuthFail}>
           {renderRoutes(route.routes)}
         </AuthWrapper>
         <Footer />

--- a/packages/polymath-issuer/src/components/AuthWrapper.js
+++ b/packages/polymath-issuer/src/components/AuthWrapper.js
@@ -52,6 +52,7 @@ const mapDispatchToProps: DispatchProps = {
 
 type Props = {|
   children: Object,
+  onFail: () => any,
 |} & StateProps &
   DispatchProps;
 
@@ -59,6 +60,17 @@ class AuthWrapper extends Component<Props> {
   handleSignUpSuccess = () => {
     this.props.tickerReservationEmail();
   };
+
+  // TODO @grsmto: Refactor the auth process so we don't have to use this hack.
+  // Ideally we should check for user authorisations at route level instead of
+  // doing this at the view level independently from the current URL/route.
+  componentDidUpdate(prevProps) {
+    const { isSignedIn, isSignedUp } = this.props;
+
+    if (!prevProps.isSignedIn && isSignedIn && !isSignedUp) {
+      this.props.onFail();
+    }
+  }
 
   render() {
     const {


### PR DESCRIPTION
As a ref here is the original issue:

> Steps to Reproduce (incl. in Production)
> - Navigate to a token-specific url (e.g. localhost:3000/dashboard/TEST-XXX)
> - Change to a metamask account that doesn't hold an account with Polymath (e.g. didn't register and verify her/his email)
> - Sign and create an account
> 
> Actual Result
> After creating an account you're redirected to a 404 page.
> 
> Expected Result
> You should be shown the email verification screen.