### PR TITLE
Fix/percentage input formatting

### DIFF
--- a/packages/polymath-issuer/src/pages/sto/components/ConfigureSTOForm/forms/USDTieredSTO/InvestmentTiers.js
+++ b/packages/polymath-issuer/src/pages/sto/components/ConfigureSTOForm/forms/USDTieredSTO/InvestmentTiers.js
@@ -212,7 +212,6 @@ class InvestmentTiers extends React.Component<Props, State> {
                 <FormItem.Input
                   component={PercentageInput}
                   placeholder="Enter percentage"
-                  unit="%"
                 />
                 <FormItem.Error />
               </FormItem>

--- a/packages/polymath-issuer/src/pages/sto/components/STOTemplatesList/index.js
+++ b/packages/polymath-issuer/src/pages/sto/components/STOTemplatesList/index.js
@@ -12,7 +12,13 @@ export default () => (
       }
 
       return map(data, stoModule => {
-        return <STOTemplate stoModule={stoModule} pickingEnabled />;
+        return (
+          <STOTemplate
+            key={stoModule.address}
+            stoModule={stoModule}
+            pickingEnabled
+          />
+        );
       });
     }}
   />

--- a/packages/polymath-ui/src/components/inputs/NumberInput/index.js
+++ b/packages/polymath-ui/src/components/inputs/NumberInput/index.js
@@ -1,7 +1,6 @@
 // @flow
 
-import React, { Component } from 'react';
-import styled from 'styled-components';
+import React, { PureComponent } from 'react';
 import numeral from 'numeral';
 
 import BaseInput from '../BaseInput';
@@ -9,33 +8,8 @@ import BaseInput from '../BaseInput';
 import type { InputProps } from '../types';
 
 type Props = InputProps & { value: string };
-type State = {| value: string |};
 
-const StyledBaseInput = styled(BaseInput)`
-  /* Remove ugly handles on Chrome/Mozilla for number inputs (until mouse hover) */
-  /* Only on desktop */
-
-  @media screen and (min-width: 768px) {
-    -moz-appearance: textfield;
-
-    ::-webkit-inner-spin-button,
-    ::-webkit-outer-spin-button {
-      -webkit-appearance: none;
-    }
-  }
-`;
-
-export default class NumberInput extends Component<Props, State> {
-  state = {
-    value: '',
-  };
-  static getDerivedStateFromProps(props: Props) {
-    const { value } = props;
-    return {
-      value,
-    };
-  }
-
+export default class NumberInput extends PureComponent<Props> {
   handleChange = (event: SyntheticInputEvent<HTMLInputElement>) => {
     const {
       field: { name },
@@ -65,7 +39,7 @@ export default class NumberInput extends Component<Props, State> {
     }
 
     return (
-      <StyledBaseInput
+      <BaseInput
         type="text"
         id={field.name}
         {...otherProps}

--- a/packages/polymath-ui/src/components/inputs/PercentageInput/PercentageInput.mdx
+++ b/packages/polymath-ui/src/components/inputs/PercentageInput/PercentageInput.mdx
@@ -1,0 +1,22 @@
+---
+name: PercentageInput
+menu: Inputs
+---
+
+import { Playground, PropsTable } from 'docz';
+import { Formik, Field }  from 'formik';
+import PercentageInput from './index';
+
+# PercentageInput
+
+<PropsTable of={PercentageInput} />
+
+## Basic usage
+
+<Playground>
+  <Formik render={(values) => (
+    <form>
+      <Field name="myText" placeholder="Your percentage" component={PercentageInput} />
+    </form>
+  )} />
+</Playground>

--- a/packages/polymath-ui/src/components/inputs/PercentageInput/index.js
+++ b/packages/polymath-ui/src/components/inputs/PercentageInput/index.js
@@ -1,9 +1,14 @@
-import React, { Component } from 'react';
+// @flow
+
+import React, { PureComponent } from 'react';
 import styled from 'styled-components';
+import numeral from 'numeral';
 
 import BaseInput from '../BaseInput';
 
 import type { InputProps } from '../types';
+
+type Props = InputProps & { value: string };
 
 const StyledBaseInput = styled(BaseInput)`
   /* Remove ugly handles on Chrome/Mozilla for number inputs (until mouse hover) */
@@ -19,17 +24,7 @@ const StyledBaseInput = styled(BaseInput)`
   }
 `;
 
-export default class PercentageInput extends Component {
-  state = {
-    value: '',
-  };
-  static getDerivedStateFromProps(props) {
-    const { value } = props;
-    return {
-      value,
-    };
-  }
-
+export default class PercentageInput extends PureComponent<Props, State> {
   handleChange = event => {
     const {
       field: { name },
@@ -39,10 +34,6 @@ export default class PercentageInput extends Component {
       target: { value },
     } = event;
 
-    let parsedValue = parseFloat(value, 10);
-    if (isNaN(parsedValue)) {
-      parsedValue = this.state.value;
-    }
     const normalizedValue = parseFloat(value, 10) / 100;
 
     setFieldValue(name, normalizedValue);
@@ -55,12 +46,24 @@ export default class PercentageInput extends Component {
       className,
       ...otherProps
     } = this.props;
-
-    const formattedValue = !isNaN(value) ? value * 100 : '';
+    const formattedValue = isNaN(value)
+      ? ''
+      : Math.max(
+          Math.min(
+            numeral(value) // This avoid strange JS decimal converting: 0.1111*100 = 11.110000000000001
+              .multiply(100)
+              .value(),
+            100
+          ),
+          0
+        );
 
     return (
       <StyledBaseInput
-        type="text"
+        type="number"
+        unit="%"
+        min={0}
+        max={100}
         id={field.name}
         value={formattedValue}
         allowEmpty={true}

--- a/packages/polymath-ui/src/components/inputs/PercentageInput/index.js
+++ b/packages/polymath-ui/src/components/inputs/PercentageInput/index.js
@@ -24,7 +24,7 @@ const StyledBaseInput = styled(BaseInput)`
   }
 `;
 
-export default class PercentageInput extends PureComponent<Props, State> {
+export default class PercentageInput extends PureComponent<Props> {
   handleChange = event => {
     const {
       field: { name },

--- a/packages/polymath-ui/src/components/inputs/TextInput/TextInput.mdx
+++ b/packages/polymath-ui/src/components/inputs/TextInput/TextInput.mdx
@@ -1,5 +1,6 @@
 ---
-name: NextTextInput
+name: TextInput
+menu: Inputs
 ---
 
 import { Playground, PropsTable } from 'docz';


### PR DESCRIPTION
- [x] I linked the issues related to this PR in its description (if any).
- [ ] If this PR adds new code that is not going to change in the near future, it includes unit tests to cover it.

- Limit input to 0 - 100
- Make `unit="%"` as default
- Use `type=number` as this shouldn't have drawbacks for percentage input
- Improve performances: remove stateful components (not sure why it was stateful) + use React.PureComponent

No tests but maybe worth adding some.