### PR TITLE
fix(issuer): change loading order of env vars

### DIFF
--- a/packages/polymath-issuer/config/env.js
+++ b/packages/polymath-issuer/config/env.js
@@ -14,13 +14,13 @@ if (!NODE_ENV) {
 
 // https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
 var dotenvFiles = [
+  paths.dotenv,
   `${paths.dotenv}.${NODE_ENV}.local`,
   `${paths.dotenv}.${NODE_ENV}`,
   // Don't include `.env.local` for `test` environment
   // since normally you expect tests to produce the same
   // results for everyone
   NODE_ENV !== 'test' && `${paths.dotenv}.local`,
-  paths.dotenv,
 ].filter(Boolean);
 
 // Load environment variables from .env* files. Suppress warnings using silent


### PR DESCRIPTION
Before this fix, .env.local was being loaded before .env, and since dotenv doesn't override previously set env vars, local env was trumping any other

**Please make sure the following boxes are checked before submitting your Pull Request:**

- [x] I linked the issues related to this PR in its description (if any).
- [x] If this PR adds new code that is not going to change in the near future, it includes unit tests to cover it.

This PR fixes https://app.asana.com/0/707624907350863/901001229644910/f