### PR TITLE
fix(issuer): fix styling of raise amount box

### DIFF
--- a/packages/polymath-issuer/src/pages/sto/components/STOOverview/views/USDTieredSTO/index.js
+++ b/packages/polymath-issuer/src/pages/sto/components/STOOverview/views/USDTieredSTO/index.js
@@ -11,6 +11,7 @@ import {
   ProgressBar,
   Countdown,
   etherscanAddress,
+  RaisedAmount,
 } from '@polymathnetwork/ui';
 import { format } from '@polymathnetwork/shared/utils';
 import {
@@ -152,15 +153,13 @@ const USDTieredSTOOverviewComponent = ({
                   {dateFormat(sto.endDate)}
                 </div>
               </div>
-              <div>
-                <div className="pui-key-value pui-countdown-raised">
-                  <div>Total Funds Raised</div>
-                  {`${format.toUSD(raised)} USD`}
-                  <div>
-                    {format.toTokens(totalTokensSold, { decimals: 2 })} {ticker}
-                  </div>
-                </div>
-              </div>
+              <RaisedAmount
+                title="Total Funds Raised"
+                primaryAmount={raised}
+                primaryUnit="USD"
+                tokenAmount={totalTokensSold}
+                tokenUnit={ticker.toUpperCase()}
+              />
             </div>
             <Box mt={4}>
               <TiersTable sto={sto} />


### PR DESCRIPTION
On STO overview, raised amount was unstyled + wrongly displayed:

![screenshot 2018-11-14 at 19 51 46](https://user-images.githubusercontent.com/527559/48515949-515b6180-e849-11e8-8e82-47361c1b5794.jpg)
