### PR TITLE
Fix/sto email start dates

### DIFF
--- a/packages/polymath-offchain/package.json
+++ b/packages/polymath-offchain/package.json
@@ -27,6 +27,7 @@
     "koa-router": "^7.4.0",
     "koa-static": "^5.0.0",
     "mongoose": "^5.0.14",
+    "moment": "2.20.1",
     "react": "16.4.0",
     "react-dom": "16.4.0",
     "web3": "1.0.0-beta.35",

--- a/packages/polymath-offchain/src/emails/CappedSTOScheduled.js
+++ b/packages/polymath-offchain/src/emails/CappedSTOScheduled.js
@@ -8,7 +8,7 @@ import { POLYMATH_ISSUER_URL, POLYMATH_OFFCHAIN_URL } from '../constants';
 
 type Props = {|
   ticker: string,
-  start: Date,
+  start: number,
   cap: number,
   rate: number,
   isPolyFundraise: boolean,
@@ -60,7 +60,12 @@ export const CappedSTOScheduled = ({
         <h3>Additional details of your Security Token Offering are below:</h3>
         <div className="value">
           <strong>Scheduled start</strong>
-          <p>{moment(start).format('MM/DD/YYYY [GMT]Z')}</p>
+          <p>
+            {moment
+              .unix(start)
+              .utc()
+              .format('MM/DD/YYYY [at] HH:mm [GMT]')}
+          </p>
         </div>
         <div className="value">
           <strong>

--- a/packages/polymath-offchain/src/emails/CappedSTOScheduled.js
+++ b/packages/polymath-offchain/src/emails/CappedSTOScheduled.js
@@ -60,7 +60,7 @@ export const CappedSTOScheduled = ({
         <h3>Additional details of your Security Token Offering are below:</h3>
         <div className="value">
           <strong>Scheduled start</strong>
-          <p>{moment(start).format('MM/DD/YYYY')}</p>
+          <p>{moment(start).format('MM/DD/YYYY [GMT]Z')}</p>
         </div>
         <div className="value">
           <strong>

--- a/packages/polymath-offchain/src/emails/USDTieredSTOScheduled.js
+++ b/packages/polymath-offchain/src/emails/USDTieredSTOScheduled.js
@@ -8,7 +8,7 @@ import { POLYMATH_ISSUER_URL, POLYMATH_OFFCHAIN_URL } from '../constants';
 
 type Props = {|
   ticker: string,
-  start: Date,
+  start: number,
   fundsReceiver: string,
   txHash: string,
   networkId: string,
@@ -41,7 +41,12 @@ export const USDTieredSTOScheduled = ({
       <h3>Additional details of your Security Token Offering are below:</h3>
       <div className="value">
         <strong>Scheduled start</strong>
-        <p>{moment(start).format('MM/DD/YYYY [GMT]Z')}</p>
+        <p>
+          {moment
+            .unix(start)
+            .utc()
+            .format('MM/DD/YYYY [at] HH:mm [GMT]')}
+        </p>
       </div>
       <div className="value">
         <strong>ETH Address to receive the funds raised during the STO</strong>

--- a/packages/polymath-offchain/src/emails/USDTieredSTOScheduled.js
+++ b/packages/polymath-offchain/src/emails/USDTieredSTOScheduled.js
@@ -41,7 +41,7 @@ export const USDTieredSTOScheduled = ({
       <h3>Additional details of your Security Token Offering are below:</h3>
       <div className="value">
         <strong>Scheduled start</strong>
-        <p>{moment(start).format('MM/DD/YYYY')}</p>
+        <p>{moment(start).format('MM/DD/YYYY [GMT]Z')}</p>
       </div>
       <div className="value">
         <strong>ETH Address to receive the funds raised during the STO</strong>

--- a/packages/polymath-offchain/src/emails/__tests__/CappedSTOScheduled.js
+++ b/packages/polymath-offchain/src/emails/__tests__/CappedSTOScheduled.js
@@ -4,7 +4,7 @@ import { CappedSTOScheduled } from '../CappedSTOScheduled';
 
 describe('Component: CappedSTOScheduled', () => {
   const ticker = 'SOMETICK';
-  const start = new Date('10/14/1987');
+  const start = 561168000;
   const cap = 1000000;
   const rate = 1000;
   const isPolyFundraise = true;

--- a/packages/polymath-offchain/src/emails/__tests__/USDTieredSTOScheduled.js
+++ b/packages/polymath-offchain/src/emails/__tests__/USDTieredSTOScheduled.js
@@ -4,7 +4,7 @@ import { USDTieredSTOScheduled } from '../USDTieredSTOScheduled';
 
 describe('Component: USDTieredSTOScheduled', () => {
   const ticker = 'SOMETICK';
-  const start = new Date('10/14/1987');
+  const start = 561168000;
   const fundsReceiver = '0xffffffffffffffff';
   const txHash = '0xeeeeeeeeeeeeeeee';
   const networkId = '15';

--- a/packages/polymath-offchain/src/emails/__tests__/__snapshots__/CappedSTOScheduled.js.snap
+++ b/packages/polymath-offchain/src/emails/__tests__/__snapshots__/CappedSTOScheduled.js.snap
@@ -290,7 +290,7 @@ exports[`Component: CappedSTOScheduled renders currency as ETH if isPolyFundrais
               Scheduled start
             </strong>
             <p>
-              10/14/1987 GMT-03:00
+              10/14/1987 at 00:00 GMT
             </p>
           </div>
           <div
@@ -709,7 +709,7 @@ exports[`Component: CappedSTOScheduled renders with all valid props 1`] = `
               Scheduled start
             </strong>
             <p>
-              10/14/1987 GMT-03:00
+              10/14/1987 at 00:00 GMT
             </p>
           </div>
           <div
@@ -1128,7 +1128,7 @@ exports[`Component: CappedSTOScheduled renders with all valid props 2`] = `
               Scheduled start
             </strong>
             <p>
-              10/14/1987 GMT-03:00
+              10/14/1987 at 00:00 GMT
             </p>
           </div>
           <div
@@ -1547,7 +1547,7 @@ exports[`Component: CappedSTOScheduled renders with invalid capRate 1`] = `
               Scheduled start
             </strong>
             <p>
-              10/14/1987 GMT-03:00
+              10/14/1987 at 00:00 GMT
             </p>
           </div>
           <div
@@ -1966,7 +1966,7 @@ exports[`Component: CappedSTOScheduled renders with invalid capRate 2`] = `
               Scheduled start
             </strong>
             <p>
-              10/14/1987 GMT-03:00
+              10/14/1987 at 00:00 GMT
             </p>
           </div>
           <div

--- a/packages/polymath-offchain/src/emails/__tests__/__snapshots__/CappedSTOScheduled.js.snap
+++ b/packages/polymath-offchain/src/emails/__tests__/__snapshots__/CappedSTOScheduled.js.snap
@@ -290,7 +290,7 @@ exports[`Component: CappedSTOScheduled renders currency as ETH if isPolyFundrais
               Scheduled start
             </strong>
             <p>
-              10/14/1987
+              10/14/1987 GMT-03:00
             </p>
           </div>
           <div
@@ -709,7 +709,7 @@ exports[`Component: CappedSTOScheduled renders with all valid props 1`] = `
               Scheduled start
             </strong>
             <p>
-              10/14/1987
+              10/14/1987 GMT-03:00
             </p>
           </div>
           <div
@@ -1128,7 +1128,7 @@ exports[`Component: CappedSTOScheduled renders with all valid props 2`] = `
               Scheduled start
             </strong>
             <p>
-              10/14/1987
+              10/14/1987 GMT-03:00
             </p>
           </div>
           <div
@@ -1547,7 +1547,7 @@ exports[`Component: CappedSTOScheduled renders with invalid capRate 1`] = `
               Scheduled start
             </strong>
             <p>
-              10/14/1987
+              10/14/1987 GMT-03:00
             </p>
           </div>
           <div
@@ -1966,7 +1966,7 @@ exports[`Component: CappedSTOScheduled renders with invalid capRate 2`] = `
               Scheduled start
             </strong>
             <p>
-              10/14/1987
+              10/14/1987 GMT-03:00
             </p>
           </div>
           <div

--- a/packages/polymath-offchain/src/emails/__tests__/__snapshots__/USDTieredSTOScheduled.js.snap
+++ b/packages/polymath-offchain/src/emails/__tests__/__snapshots__/USDTieredSTOScheduled.js.snap
@@ -290,7 +290,7 @@ exports[`Component: USDTieredSTOScheduled renders with all valid props 1`] = `
               Scheduled start
             </strong>
             <p>
-              10/14/1987
+              10/14/1987 GMT-03:00
             </p>
           </div>
           <div

--- a/packages/polymath-offchain/src/emails/__tests__/__snapshots__/USDTieredSTOScheduled.js.snap
+++ b/packages/polymath-offchain/src/emails/__tests__/__snapshots__/USDTieredSTOScheduled.js.snap
@@ -290,7 +290,7 @@ exports[`Component: USDTieredSTOScheduled renders with all valid props 1`] = `
               Scheduled start
             </strong>
             <p>
-              10/14/1987 GMT-03:00
+              10/14/1987 at 00:00 GMT
             </p>
           </div>
           <div

--- a/packages/polymath-offchain/src/startup/__tests__/setupWeb3.js
+++ b/packages/polymath-offchain/src/startup/__tests__/setupWeb3.js
@@ -939,7 +939,7 @@ describe('Function: moduleAddedHandler', () => {
       validWalletAddress,
       validIsPolyFundraise,
       validRate,
-      new Date(validStart * 1000),
+      validStart,
       validNetworkId
     );
   });
@@ -973,7 +973,7 @@ describe('Function: moduleAddedHandler', () => {
       validTxHash,
       validTicker,
       validWalletAddress,
-      new Date(validStart * 1000),
+      validStart,
       validNetworkId
     );
   });

--- a/packages/polymath-offchain/src/startup/setupWeb3.js
+++ b/packages/polymath-offchain/src/startup/setupWeb3.js
@@ -155,7 +155,7 @@ const newProvider = async (networkId: string) => {
 
   @returns an object with the STO details:
 
-    - start (start date)
+    - start (start time as a unix timestamp)
     - cap (maximum amount of tokens to sell)
     - rate (how many tokens for 1 ETH/POLY)
     - isPolyFundraise (is the currency POLY or ETH)
@@ -187,7 +187,7 @@ const getCappedSTODetails = async (address: string, networkId: string) => {
      *
      * Start time is a UNIX timestamp (in seconds)
      */
-    const start = new Date(details[0] * 1000);
+    const start: number = details[0];
     const cap: number = Web3.utils.fromWei(details[2]);
     const rate: number = details[3];
     const isPolyFundraise: boolean = details[7];
@@ -216,7 +216,7 @@ const getCappedSTODetails = async (address: string, networkId: string) => {
     NOTE @monitz87: this should be updated as soon as we have design for
     the USD Tiered STO email
 
-    - start (start date)
+    - start (start time as a unix timestamp)
     - fundsReceiver (wallet to which the funds will be transfered)
  */
 const getUSDTieredSTODetails = async (address: string, networkId: string) => {
@@ -227,7 +227,7 @@ const getUSDTieredSTODetails = async (address: string, networkId: string) => {
     const fundsReceiver: string = await contract.methods.wallet().call();
 
     return {
-      start: new Date(start * 1000),
+      start,
       fundsReceiver,
     };
   } catch (error) {

--- a/packages/polymath-offchain/src/utils/emails.js
+++ b/packages/polymath-offchain/src/utils/emails.js
@@ -180,7 +180,7 @@ export const sendTokenCreatedEmail = async (
  * @param {string} fundsReceiver wallet address that investment funds will be transferred to
  * @param {boolean} isPolyFundraise true if the funds are raised in POLY, false if they are raised in ETH
  * @param {number} rate conversion rate between currency of choice and the issuer's security token
- * @param {Date} start start date of the STO
+ * @param {number} start start time of the STO as a unix timestamp
  * @param {string} networkId id of the network in which the STO was scheduled
  */
 export const sendCappedSTOScheduledEmail = async (
@@ -192,7 +192,7 @@ export const sendCappedSTOScheduledEmail = async (
   fundsReceiver: string,
   isPolyFundraise: boolean,
   rate: number,
-  start: Date,
+  start: number,
   networkId: string
 ) => {
   await sendEmail(
@@ -222,7 +222,7 @@ export const sendCappedSTOScheduledEmail = async (
  * @param {string} txHash transaction hash
  * @param {string} ticker name of the issuer's security token
  * @param {string} fundsReceiver wallet address that investment funds will be transferred to
- * @param {Date} start start date of the STO
+ * @param {number} start start time of the STO as a unix timestamp
  * @param {string} networkId id of the network in which the STO was scheduled
  */
 export const sendUSDTieredSTOScheduledEmail = async (
@@ -231,7 +231,7 @@ export const sendUSDTieredSTOScheduledEmail = async (
   txHash: string,
   ticker: string,
   fundsReceiver: string,
-  start: Date,
+  start: number,
   networkId: string
 ) => {
   await sendEmail(


### PR DESCRIPTION
**Please make sure the following boxes are checked before submitting your Pull Request:**

- [x] I linked the issues related to this PR in its description (if any).
- [x] If this PR adds new code that is not going to change in the near future, it includes unit tests to cover it.

This PR shows STO start dates in emails together with time and timezone. It also eliminates in-between wrapping of timestamps with `Date` objects