### PR TITLE
fix(issuer): split states of investors number for token creation

### DIFF
--- a/packages/polymath-issuer/src/pages/token/TokenPage.js
+++ b/packages/polymath-issuer/src/pages/token/TokenPage.js
@@ -16,7 +16,6 @@ import {
   Countdown,
   Remark,
   NotFoundPage,
-  confirm,
 } from '@polymathnetwork/ui';
 import moment from 'moment';
 import type { SecurityToken } from '@polymathnetwork/js/types';
@@ -52,7 +51,6 @@ type DispatchProps = {|
   limitNumberOfInvestors: (count?: number) => any,
   updateMaxHoldersCount: (count: number) => any,
   exportMintedTokensList: () => any,
-  confirm: () => any,
 |};
 
 const mapStateToProps = (state: RootState): StateProps => ({
@@ -71,7 +69,6 @@ const mapDispatchToProps: DispatchProps = {
   limitNumberOfInvestors,
   updateMaxHoldersCount,
   exportMintedTokensList,
-  confirm,
 };
 
 type Props = {||} & StateProps & DispatchProps;
@@ -101,10 +98,6 @@ class TokenPage extends Component<Props, State> {
       this.setState({ maxHoldersCount: nextProps.maxHoldersCount });
     }
   }
-
-  handleToggleCreate = (isToggled: boolean) => {
-    this.setState({ isToggled });
-  };
 
   handleToggle = (isToggled: boolean) => {
     const { isCountTMEnabled, isCountTMPaused } = this.props;
@@ -142,8 +135,10 @@ class TokenPage extends Component<Props, State> {
     }
   };
 
-  handleIssue = () => {
-    this.props.issue(this.state.isToggled);
+  handleIssue = formData => {
+    const isLimitNI = !!formData.investorsNumber;
+
+    this.props.issue(isLimitNI);
   };
 
   handleExport = () => {
@@ -185,7 +180,6 @@ class TokenPage extends Component<Props, State> {
                     </h3>
                     <br />
                     <CompleteTokenForm
-                      onToggle={this.handleToggleCreate}
                       isToggled={this.state.isToggled}
                       onSubmit={this.handleIssue}
                     />

--- a/packages/polymath-issuer/src/pages/token/components/CompleteTokenForm.js
+++ b/packages/polymath-issuer/src/pages/token/components/CompleteTokenForm.js
@@ -17,13 +17,30 @@ export const formName = 'complete_token';
 const minValue1 = minValue(1);
 
 type Props = {
-  handleSubmit: (isDivisible: boolean) => void,
+  onSubmit: (isLimitNI: boolean) => void,
   onToggle: (isToggled: boolean) => void,
+};
+
+type State = {
   isToggled: boolean,
 };
 
-class CompleteTokenForm extends Component<Props> {
+class CompleteTokenForm extends Component<Props, State> {
+  state = {
+    isToggled: false,
+  };
+
+  handleToggle = (isToggled: boolean) => {
+    this.setState({ isToggled });
+  };
+
+  handleSubmit = () => {
+    this.props.onSubmit(this.state.isToggled);
+  };
+
   render() {
+    const { isToggled } = this.state;
+
     return (
       <Form onSubmit={this.props.handleSubmit} className="token-form">
         <div className="token-form-left">
@@ -70,10 +87,7 @@ class CompleteTokenForm extends Component<Props> {
               </Tooltip>
             }
           >
-            <Toggle
-              onToggle={this.props.onToggle}
-              id="investors-number-toggle"
-            />
+            <Toggle onToggle={this.handleToggle} id="investors-number-toggle" />
           </FormGroup>
         </div>
         <div className="token-form-right">
@@ -97,7 +111,7 @@ class CompleteTokenForm extends Component<Props> {
               validate={[url]}
             />
           </FormGroup>
-          {this.props.isToggled ? (
+          {isToggled ? (
             <FormGroup
               legendText="Max. Number of Investors"
               style={{ marginTop: '24px' }}


### PR DESCRIPTION
**Please make sure the following boxes are checked before submitting your Pull Request:**

- [x] I linked the issues related to this PR in its description (if any).
- [x] If this PR adds new code that is not going to change in the near future, it includes unit tests to cover it.

Cleanest way I found. Split the states. Other way was the `componentDidUpdate`, was easier, but was dirty.
