### PR TITLE
fix(ui): add a wrapping element on CurrencySelect

### DIFF
--- a/packages/polymath-ui/src/components/inputs/CurrencySelect/Input/index.js
+++ b/packages/polymath-ui/src/components/inputs/CurrencySelect/Input/index.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { Fragment } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import Select, { components } from 'react-select';
 
@@ -81,7 +81,6 @@ const SelectContainer = styled(Box)`
   vertical-align: middle;
   min-width: 200px;
   margin-right: ${({ theme }) => theme.space[4]}px;
-  margin-bottom: ${({ theme }) => theme.space[1]}px;
 `;
 
 const Caret = styled(Icon)`
@@ -142,7 +141,7 @@ export default class Input extends React.Component<Props> {
       : value;
 
     return (
-      <Fragment>
+      <div>
         <SelectContainer>
           <Select
             closeMenuOnSelect={false}
@@ -175,7 +174,7 @@ export default class Input extends React.Component<Props> {
               />
             ) : null;
           })}
-      </Fragment>
+      </div>
     );
   }
 }


### PR DESCRIPTION
error message or other siblings elements displayed incorrectly otherwise.

This PR solves this:
![image](https://user-images.githubusercontent.com/527559/49018363-5d60f080-f172-11e8-8c6c-0941f8c7549a.png)

Note: this is intended to be a hotfix. So this should be merge in both `master` and `develop`. Or we can cherry-pick later otherwise, depending on how we want to do!