### PR TITLE
fix: adapt STO deployment to core 2.1

### DIFF
--- a/packages/polymath-issuer/src/pages/sto/components/ConfigureSTOForm/forms/CappedSTO/index.js
+++ b/packages/polymath-issuer/src/pages/sto/components/ConfigureSTOForm/forms/CappedSTO/index.js
@@ -258,7 +258,7 @@ const formikEnhancer = withFormik({
         moment(values.date.startDate).unix() * 1000 + values.date.startTime,
       endsAt: moment(values.date.endDate).unix() * 1000 + values.date.endTime,
       cap: toWei(values.cap),
-      rate: values.rate.toString(),
+      rate: toWei(values.rate.toString()),
       currencies: [FUND_RAISE_TYPES[values.currency]],
       receiverAddress: values.receiverAddress,
     };

--- a/packages/polymath-issuer/src/utils/contracts/index.js
+++ b/packages/polymath-issuer/src/utils/contracts/index.js
@@ -116,7 +116,7 @@ function encodeUSDTieredSTOSetupCall(params: USDTieredSTOParams) {
           name: '_reserveWallet',
         },
         {
-          type: 'address',
+          type: 'address[]',
           name: '_usdToken',
         },
       ],
@@ -133,7 +133,7 @@ function encodeUSDTieredSTOSetupCall(params: USDTieredSTOParams) {
       params.fundRaiseTypes,
       params.wallet,
       params.reserveWallet,
-      params.usdToken,
+      [params.usdToken],
     ]
   );
 }

--- a/packages/polymath-js/src/contracts/PolyToken.js
+++ b/packages/polymath-js/src/contracts/PolyToken.js
@@ -86,7 +86,6 @@ export class PolyToken extends Contract {
 
     const callbackInternal = (event: Web3Event) => {
       const values = event.returnValues;
-      console.log('VALUES', values);
 
       const value = new BigNumber(values[valueKey]);
       const isSent = values[fromKey] === this.account;

--- a/packages/polymath-js/src/contracts/PolyToken.js
+++ b/packages/polymath-js/src/contracts/PolyToken.js
@@ -80,23 +80,13 @@ export class PolyToken extends Contract {
   async subscribeMyTransfers(
     callback: (toOrFrom: Address, value: BigNumber, isSent: boolean) => void
   ) {
-    /**
-     * NOTE @monitz87: this differentiation of parameter names
-     * is necessary due to https://github.com/PolymathNetwork/polymath-core/issues/412
-     */
-    const networkId = String(Contract._params.id);
-    let valueKey = 'value',
+    const valueKey = 'value',
       toKey = 'to',
       fromKey = 'from';
 
-    if (networkId !== MAINNET_NETWORK_ID) {
-      valueKey = `_${valueKey}`;
-      fromKey = `_${fromKey}`;
-      toKey = `_${toKey}`;
-    }
-
     const callbackInternal = (event: Web3Event) => {
       const values = event.returnValues;
+      console.log('VALUES', values);
 
       const value = new BigNumber(values[valueKey]);
       const isSent = values[fromKey] === this.account;

--- a/packages/polymath-offchain/src/startup/setupWeb3.js
+++ b/packages/polymath-offchain/src/startup/setupWeb3.js
@@ -189,7 +189,7 @@ const getCappedSTODetails = async (address: string, networkId: string) => {
      */
     const start: number = details[0];
     const cap: number = Web3.utils.fromWei(details[2]);
-    const rate: number = details[3];
+    const rate: number = Web3.utils.fromWei(details[3]);
     const isPolyFundraise: boolean = details[7];
 
     return {


### PR DESCRIPTION
**Please make sure the following boxes are checked before submitting your Pull Request:**

- [x] I linked the issues related to this PR in its description (if any).
- [x] If this PR adds new code that is not going to change in the near future, it includes unit tests to cover it.

This PR:
- Fixes a bug caused by updating the local blockchain to 2.1 (there have been breaking changes in both STOs in the new contracts)
- Removes the workaround that fixed discrepancies in event parameter names between the PolyToken and PolytokenFaucet (in 2.1 they standardized the names)

**WARNING:** do NOT merge this PR if we plan to release in legacy before 2.1 is live in mainnet or STOs will break there. This fix should be only for local testing