### PR TITLE
Chore/offchain retries env

### DIFF
--- a/packages/new-polymath-scripts/README.md
+++ b/packages/new-polymath-scripts/README.md
@@ -12,9 +12,9 @@ usage: `yarn local-blockchain:generate-fixtures`
 
 Starts an instance of the ganache CLI and populates the local blockchain with the seed data provided in a JSON file.
 
-usage: `yarn local-blockchain:start --seedData <relative_path_to_json>`
+usage: `yarn local-blockchain:start --seedData <absolute_path_to_json>`
 
-example `yarn local-blockchain:start --seedData ./myData.json`
+example `yarn local-blockchain:start --seedData /FObrien/I/Know/Youre/Reading/This/myData.json`
 
 (The script loads `seedData.json` by default)
 

--- a/packages/new-polymath-scripts/src/populateLocalBlockchain/index.js
+++ b/packages/new-polymath-scripts/src/populateLocalBlockchain/index.js
@@ -2,6 +2,7 @@ const { sendTransaction, web3 } = require('../utils');
 const { BLOCKCHAIN_NETWORK_ID, STATE_DOCUMENT_PATH } = require('../constants');
 const wallets = require('./wallets.json');
 const fs = require('fs');
+const path = require('path');
 const _ = require('lodash');
 
 function consoleOutput(data) {
@@ -86,7 +87,7 @@ function markdownOutput(data) {
 async function seedData(dataFile) {
   if (fs.existsSync(STATE_DOCUMENT_PATH)) fs.unlinkSync(STATE_DOCUMENT_PATH);
 
-  const accounts = require(`./${dataFile}`).accounts;
+  const accounts = require(dataFile).accounts;
 
   const PolymathRegistryArtifact = require('../fixtures/contracts/PolymathRegistry.json');
   const SecurityTokenRegistryArtifact = require('../fixtures/contracts/SecurityTokenRegistry.json');
@@ -267,7 +268,9 @@ async function seedData(dataFile) {
       throw new Error(`No value set for option '${flag}'`);
     }
   }
-  const dataFile = arg || 'seedData.json';
+
+  const dataFile = arg || `${__dirname}/seedData.json`;
+
   console.log(`Reading seed data from "${dataFile}"`);
-  await seedData(dataFile);
+  await seedData(path.resolve(dataFile));
 })().catch(console.log);

--- a/packages/new-polymath-scripts/src/startLocalBlockchain/index.js
+++ b/packages/new-polymath-scripts/src/startLocalBlockchain/index.js
@@ -6,11 +6,25 @@ const { PACKAGE_ROOT_DIR } = require('../constants');
     cwd: PACKAGE_ROOT_DIR,
   });
 
-  await startCli(`${PACKAGE_ROOT_DIR}/build/fixtures/blockchain-state`);
+  let [, , flag0, arg0, flag1, arg1] = process.argv;
 
-  const [, , flag, arg] = process.argv;
+  if (flag1 && flag1 !== 'seedData') {
+    [flag0, flag1] = [flag1, flag0];
+    [arg0, arg1] = [arg1, arg0];
+  }
+
+  if (flag0 !== '-e') {
+    throw new Error(`Invalid flag "${flag0}", should be "-e"`);
+  } else if (isNaN(arg0)) {
+    throw new Error('Must supply a numerical value for "-e"');
+  }
+
+  await startCli(`${PACKAGE_ROOT_DIR}/build/fixtures/blockchain-state`, {
+    initialEther: arg0,
+  });
+
   await runCommand(
-    `yarn local-blockchain:seed ${flag ? `${flag} ${arg}` : ''}`,
+    `yarn local-blockchain:seed ${flag1 ? `${flag1} ${arg1}` : ''}`,
     {
       cwd: PACKAGE_ROOT_DIR,
     }

--- a/packages/new-polymath-scripts/src/utils.js
+++ b/packages/new-polymath-scripts/src/utils.js
@@ -84,7 +84,13 @@ async function sendTransaction(userAccount, action, address) {
   );
 }
 
-async function startCli(db) {
+async function startCli(db, opts = {}) {
+  let { initialEther } = opts;
+
+  if (!initialEther) {
+    initialEther = INITIAL_ETHER;
+  }
+
   const ganacheArgs = [
     // Set a directory to which ganache will write the state to
     `--db="${db}"`,
@@ -93,7 +99,7 @@ async function startCli(db) {
     // Set a network id for ganache
     `-i=${BLOCKCHAIN_NETWORK_ID}`,
     // Set an initial amount of ether for all wallets
-    `-e=${INITIAL_ETHER}`,
+    `-e=${initialEther}`,
     `--mnemonic="${BLOCKCHAIN_MNEMONIC}"`,
     `--accounts=${ACCOUNT_NUMBER}`,
     // Sets deterministic mode to ensure same accounts everytime

--- a/packages/polymath-offchain/.env.local
+++ b/packages/polymath-offchain/.env.local
@@ -16,6 +16,8 @@
 # Server
 # ------------------------------------------------------------------------------
 # * PORT: Web server's port
+# * CRITICAL_RETRIES: Amount of retries for mandatory blockchain connections
+# * OPTIONAL_RETRIES: Amount of retries for optional (testing) blockchain connections
 #
 # Apps
 # ------------------------------------------------------------------------------
@@ -36,7 +38,9 @@
 WEB3_NETWORK_LOCAL_WS="ws://localhost:8545"
 POLYMATH_REGISTRY_ADDRESS_LOCAL="0x8f0483125fcb9aaaefa9209d8e9d7b9c8b9fb90f"
 
-PORT=3001
+PORT="3001"
+CRITICAL_RETRIES="5"
+OPTIONAL_RETRIES="0"
 
 POLYMATH_OFFCHAIN_URL="http://localhost:3001"
 POLYMATH_ISSUER_URL="http://localhost:3000"

--- a/packages/polymath-offchain/src/constants.js
+++ b/packages/polymath-offchain/src/constants.js
@@ -37,6 +37,8 @@ type Environment = {|
   DEPLOYMENT_STAGE: string,
   MONGODB_URI: string,
   SENDGRID_API_KEY?: string,
+  CRITICAL_RETRIES: string,
+  OPTIONAL_RETRIES: string,
 |};
 
 const env = cleanEnvironment<Environment>(process.env, [
@@ -68,8 +70,8 @@ export const MONGODB_URI = env.MONGODB_URI;
 export const NODE_ENV = env.NODE_ENV;
 export const DEPLOYMENT_STAGE = env.DEPLOYMENT_STAGE;
 
-const CRITICAL_RETRIES = 5; // Amount of retries for mandatory connections
-const OPTIONAL_RETRIES = 0; // Amount of retries for optional (testing) connections
+const CRITICAL_RETRIES = parseInt(env.CRITICAL_RETRIES, 10);
+const OPTIONAL_RETRIES = parseInt(env.OPTIONAL_RETRIES, 10);
 
 /**
   Blockchain network params


### PR DESCRIPTION
**Please make sure the following boxes are checked before submitting your Pull Request:**

- [x] I linked the issues related to this PR in its description (if any).
- [x] If this PR adds new code that is not going to change in the near future, it includes unit tests to cover it.

This PR:
- Adds env vars to control the amount of blockchain connection retries in offchain
- Changes the seed data path in the local blockchain script from relative to absolute
- Adds the `-e` flag to the local blockchain script to specify how much ether the accounts start with