### PR TITLE
fix(polymath-scripts): make initial ether flag optional

### DIFF
--- a/packages/new-polymath-scripts/src/startLocalBlockchain/index.js
+++ b/packages/new-polymath-scripts/src/startLocalBlockchain/index.js
@@ -13,9 +13,9 @@ const { PACKAGE_ROOT_DIR } = require('../constants');
     [arg0, arg1] = [arg1, arg0];
   }
 
-  if (flag0 !== '-e') {
+  if (flag0 && flag0 !== '-e') {
     throw new Error(`Invalid flag "${flag0}", should be "-e"`);
-  } else if (isNaN(arg0)) {
+  } else if (flag0 && isNaN(arg0)) {
     throw new Error('Must supply a numerical value for "-e"');
   }
 


### PR DESCRIPTION
**Please make sure the following boxes are checked before submitting your Pull Request:**

- [x] I linked the issues related to this PR in its description (if any).
- [x] If this PR adds new code that is not going to change in the near future, it includes unit tests to cover it.

This PR makes the `-e` flag optional in the local blockchain script