### PR TITLE
fix: enable minting after an STO has been completed

### DIFF
--- a/packages/polymath-issuer/src/pages/sto/STOPage.js
+++ b/packages/polymath-issuer/src/pages/sto/STOPage.js
@@ -12,6 +12,7 @@ import {
   STAGE_SELECT,
   STAGE_CONFIGURE,
   STAGE_OVERVIEW,
+  STAGE_COMPLETED,
 } from '../../reducers/sto';
 import SelectSTOTemplate from './components/SelectSTOTemplate';
 import STOOverview from './components/STOOverview';
@@ -56,6 +57,7 @@ class STOPage extends Component<Props> {
       case STAGE_CONFIGURE:
         return <ConfigureSTO />;
       case STAGE_OVERVIEW:
+      case STAGE_COMPLETED:
         return <STOOverview />;
       default:
         return <Loading />;

--- a/packages/polymath-issuer/src/pages/sto/components/STOOverview/views/USDTieredSTO/TiersTable.js
+++ b/packages/polymath-issuer/src/pages/sto/components/STOOverview/views/USDTieredSTO/TiersTable.js
@@ -88,7 +88,7 @@ const USDTieredSTOTiersTable = ({ sto: { tiers } }: Props) => {
         progress: (
           <InlineFlex key={id}>
             <Box maxWidth="150px" mr={1}>
-              <ProgressBar height="10" progress={progress.toNumber()} />
+              <ProgressBar height="10" progress={progress.toNumber() * 100} />
             </Box>
             {format.toPercent(progress)}
           </InlineFlex>

--- a/packages/polymath-issuer/src/pages/sto/components/STOOverview/views/USDTieredSTO/index.js
+++ b/packages/polymath-issuer/src/pages/sto/components/STOOverview/views/USDTieredSTO/index.js
@@ -164,7 +164,7 @@ const USDTieredSTOOverviewComponent = ({
                   </div>
                 </div>
                 <Box mb={4}>
-                  <ProgressBar progress={totalUsdRaisedPercent / 100} />
+                  <ProgressBar progress={totalUsdRaisedPercent} />
                 </Box>
                 <Grid
                   gridTemplateColumns={['', '', '', '1fr minmax(250px, 1fr)']}

--- a/packages/polymath-issuer/src/reducers/sto.js
+++ b/packages/polymath-issuer/src/reducers/sto.js
@@ -14,6 +14,7 @@ export const STAGE_FETCHING = 0;
 export const STAGE_SELECT = 1;
 export const STAGE_CONFIGURE = 2;
 export const STAGE_OVERVIEW = 3;
+export const STAGE_COMPLETED = 4;
 
 export type STOState = {
   stage: number,
@@ -37,13 +38,26 @@ const defaultState: STOState = {
 
 export default (state: STOState = defaultState, action: Action) => {
   switch (action.type) {
-    case a.DATA:
+    case a.DATA: {
+      const now = new Date();
+      const { details, contract } = action;
+      let isFinished = false;
+      if (details) {
+        const { capReached, isOpen, end, endDate } = details;
+        const finishDate = end || endDate;
+        isFinished = (capReached && !isOpen) || now >= finishDate;
+      }
       return {
         ...state,
-        stage: action.contract ? STAGE_OVERVIEW : STAGE_SELECT,
-        contract: action.contract,
-        details: action.details,
+        stage: contract
+          ? isFinished
+            ? STAGE_COMPLETED
+            : STAGE_OVERVIEW
+          : STAGE_SELECT,
+        contract: contract,
+        details: details,
       };
+    }
     case a.FACTORIES:
       return {
         ...state,

--- a/packages/polymath-js/src/contracts/STO.js
+++ b/packages/polymath-js/src/contracts/STO.js
@@ -55,6 +55,16 @@ export default class STO extends Contract {
       isPolyFundraise,
     ] = this._toArray(await this._methods.getSTODetails().call());
 
+    const now = new Date().getTime() / 1000;
+    const capReached = await this._methods.capReached().call();
+    const isPaused = await this._methods.paused().call();
+    const isOpen = !(
+      isPaused ||
+      capReached ||
+      now < startTime ||
+      now > endTime
+    );
+
     return {
       address: this.address,
       start: this._toDate(startTime),
@@ -62,6 +72,8 @@ export default class STO extends Contract {
       cap: this._fromWei(cap),
       raised: this._fromWei(fundsRaised),
       tokensSold: this.token.removeDecimals(tokensSold),
+      capReached,
+      isOpen,
       rate,
       investorCount,
       isPolyFundraise,

--- a/packages/polymath-js/src/types.js
+++ b/packages/polymath-js/src/types.js
@@ -121,6 +121,8 @@ export type STODetails = {|
   cap: BigNumber,
   raised: BigNumber,
   tokensSold: BigNumber,
+  isOpen: boolean,
+  capReached: boolean,
   rate: number,
   investorCount: number,
   isPolyFundraise: boolean,


### PR DESCRIPTION
Also fix progress bars (once again)

**Please make sure the following boxes are checked before submitting your Pull Request:**

- [x] I've added this PR's link to its Asana task(s)
- [x] If this PR adds new code that is not going to change in the near future, it includes unit tests to cover it.

This PR fixes a bug where an issuer couldn't mint tokens even after an STO had been finished. It also fixes the STO overview progress bars being passed values between 0 and 1 instead of percentages, which caused them to look 1/100 of their actual size