### PR TITLE
fix(issuer): hacky fix for programatically changing routes

### DIFF
--- a/packages/polymath-ui/src/components/TxModal/actions.js
+++ b/packages/polymath-ui/src/components/TxModal/actions.js
@@ -57,7 +57,9 @@ export const txContinue = () => async (
     }
     //TODO @grsmto: UI components should not call any history change directly. That should be handled with a callback not by this component directly.
     if (continueRoute) {
+      // NOTE @RafaelVidaurre: Hack to get programatical route changes working
       // $FlowFixMe
+      getState().pui.common.history.push(continueRoute);
       getState().pui.common.history.push(continueRoute);
     }
   } else {


### PR DESCRIPTION
**Please make sure the following boxes are checked before submitting your Pull Request:**

- [x] I've added this PR's link to its Asana task(s)
- [ ] If this PR adds new code that is not going to change in the near future, it includes unit tests to cover it.

# This PR

Introduces a temporary hack to get route changes done. For some reason route changes through dispatch are broken unless they are dispatched twice. 

I apologize for the horrible fix, this is only a temporary fix to avoid having a release blocker for dividends. This should be revisited once the urgent tasks for dividends are ready.

(Note that this only on legacy)
