### PR TITLE
Fix display of cappedsto raisedamount

### DIFF
--- a/packages/polymath-issuer/src/pages/sto/components/ConfigureSTOForm/forms/CappedSTO/index.js
+++ b/packages/polymath-issuer/src/pages/sto/components/ConfigureSTOForm/forms/CappedSTO/index.js
@@ -195,7 +195,7 @@ export const CappedSTOFormComponent = ({
           <FormItem.Error />
         </FormItem>
         <Grid gridAutoFlow="column" gridAutoColumns="1fr">
-          <Grid.Item gridColumn="span 3 / 5">
+          <Grid.Item gridColumn="span 1 / 4">
             <RaisedAmount
               title="Amount Of Funds the STO Will Raise"
               primaryAmount={format.toTokens(totalRaiseAmount, {

--- a/packages/polymath-issuer/src/pages/sto/components/ConfigureSTOForm/forms/CappedSTO/index.js
+++ b/packages/polymath-issuer/src/pages/sto/components/ConfigureSTOForm/forms/CappedSTO/index.js
@@ -195,7 +195,7 @@ export const CappedSTOFormComponent = ({
           <FormItem.Error />
         </FormItem>
         <Grid gridAutoFlow="column" gridAutoColumns="1fr">
-          <Grid.Item gridColumn="span 1 / 4">
+          <Grid.Item gridColumn="span 3 / 5">
             <RaisedAmount
               title="Amount Of Funds the STO Will Raise"
               primaryAmount={format.toTokens(totalRaiseAmount, {

--- a/packages/polymath-issuer/src/pages/sto/components/ConfigureSTOForm/forms/CappedSTO/index.js
+++ b/packages/polymath-issuer/src/pages/sto/components/ConfigureSTOForm/forms/CappedSTO/index.js
@@ -195,7 +195,7 @@ export const CappedSTOFormComponent = ({
           <FormItem.Error />
         </FormItem>
         <Grid gridAutoFlow="column" gridAutoColumns="1fr">
-          <Grid.Item gridColumn="span 1 / 4">
+          <Grid.Item gridColumn="span 2 / 4">
             <RaisedAmount
               title="Amount Of Funds the STO Will Raise"
               primaryAmount={format.toTokens(totalRaiseAmount, {

--- a/packages/polymath-shared/src/utils/format.js
+++ b/packages/polymath-shared/src/utils/format.js
@@ -95,5 +95,5 @@ export const toTokens = (
   }
   return new BigNumber(number.toPrecision(precision))
     .toFormat(decimals, 1)
-    .replace(/\.?0+$/, '');
+    .replace(/([0-9]+(\.[0-9]+[1-9])?)(\.?0+$)/, '$1');
 };

--- a/packages/polymath-shared/src/utils/format.js
+++ b/packages/polymath-shared/src/utils/format.js
@@ -95,5 +95,5 @@ export const toTokens = (
   }
   return new BigNumber(number.toPrecision(precision))
     .toFormat(decimals, 1)
-    .replace(/([0-9]+(\.[0-9]+[1-9])?)(\.?0+$)/, '$1');
+    .replace(/\.?0+$/, '');
 };


### PR DESCRIPTION
This PR fixes the removal of trailing zeros and resizes the raised amount container since the max digits for hard cap is now set

**Please make sure the following boxes are checked before submitting your Pull Request:**

- [x] I've added this PR's link to its Asana task(s)
- [ ] If this PR adds new code that is not going to change in the near future, it includes unit tests to cover it.
