### PR TITLE
fix(new-issuer): use actual data in the dividend card

### DIFF
--- a/packages/new-polymath-issuer/src/components/DividendCard/DividendCard.tsx
+++ b/packages/new-polymath-issuer/src/components/DividendCard/DividendCard.tsx
@@ -4,7 +4,6 @@ import {
   Box,
   Card,
   Heading,
-  ButtonFluid,
   CardPrimary,
   Icon,
   icons,
@@ -14,14 +13,54 @@ import {
   Label,
   theme,
   IconCircled,
+  ButtonLink,
+  ButtonFluid,
 } from '@polymathnetwork/new-ui';
+import { DIVIDEND_PAYMENT_INVESTOR_BATCH_SIZE } from '~/constants';
+import BigNumber from 'bignumber.js';
 
 interface Props {
-  dividend: types.DividendPojo;
+  dividend: types.DividendEntity;
   securityTokenSymbol: string;
 }
 
 export const DividendCard: FC<Props> = ({ dividend, securityTokenSymbol }) => {
+  const {
+    investors,
+    currency,
+    expiry,
+    totalWithheld,
+    totalWithheldWithdrawn,
+  } = dividend;
+  const currencyLabel = (currency || 'UNNAMED TOKEN').toUpperCase();
+  let currencyType: string;
+  let currencyColor: string;
+
+  const remainingPayments = investors.filter(
+    investor => !investor.paymentReceived && !investor.excluded
+  ).length;
+  const remainingTransactions = Math.ceil(
+    remainingPayments / DIVIDEND_PAYMENT_INVESTOR_BATCH_SIZE
+  );
+  const unwithdrawnTaxes = totalWithheld.minus(totalWithheldWithdrawn);
+  const dividendComplete =
+    expiry <= new Date() ||
+    (remainingTransactions === 0 && unwithdrawnTaxes.eq(new BigNumber(0)));
+
+  switch (currencyLabel) {
+    case types.Tokens.Dai:
+    case types.Tokens.Poly: {
+      currencyColor = theme.tokens[currencyLabel].color;
+      currencyType = currencyLabel;
+      break;
+    }
+    default: {
+      currencyColor = theme.tokens[types.Tokens.Erc20].color;
+      currencyType = 'ERC20';
+      break;
+    }
+  }
+
   return (
     <Card width={300} height={370} p="gridGap">
       <Flex flexDirection="column" height="100%" alignItems="flex-start">
@@ -31,42 +70,51 @@ export const DividendCard: FC<Props> = ({ dividend, securityTokenSymbol }) => {
               <span>Dividend Amount</span>
             </Text>
             <Text fontSize={0} color="gray.2">
-              <span>Not completed</span>
+              <span>{dividendComplete ? 'Completed' : 'Not completed'}</span>
               <Icon
                 Asset={icons.SvgDot}
                 width={16}
                 height={16}
-                color="warning"
+                color={dividendComplete ? 'success' : 'warning'}
               />
             </Text>
           </Flex>
           <Paragraph fontSize={4} color="baseText" mt="m">
-            {formatters.toTokens(dividend.amount)} {securityTokenSymbol}
+            {formatters.toTokens(dividend.amount)} {currencyLabel}
           </Paragraph>
         </CardPrimary>
         <Heading mt="m" mb={1}>
           {dividend.name}
         </Heading>
-        <Label color={theme.tokens[types.Tokens.Erc20].color}>
-          Issued in ERC20
-        </Label>
-        <Flex mt="m">
-          <Flex flex="0" mr="s">
-            <IconCircled
-              Asset={icons.SvgWarning}
-              width={26}
-              height={26}
-              color="white"
-              bg="warning"
-              scale={0.9}
-            />
+        <Label color={currencyColor}>Issued in {currencyType}</Label>
+        {!dividendComplete && (
+          <Flex mt="m">
+            <Flex flex="0" mr="s">
+              <IconCircled
+                Asset={icons.SvgWarning}
+                width={26}
+                height={26}
+                color="white"
+                bg="warning"
+                scale={0.9}
+              />
+            </Flex>
+            {remainingTransactions > 0 && (
+              <Paragraph fontSize={0}>
+                <strong>{remainingTransactions}</strong> remaining transactions
+              </Paragraph>
+            )}
+            {remainingTransactions === 0 && (
+              <Paragraph fontSize={0}>
+                <strong>{formatters.toTokens(unwithdrawnTaxes)}</strong> tax
+                withholdings left to withdraw
+              </Paragraph>
+            )}
           </Flex>
-          <Paragraph fontSize={0}>
-            <strong>2</strong> Remaining transactions
-          </Paragraph>
-        </Flex>
+        )}
         <Box mt="auto" minWidth="100%" textAlign="center">
           <ButtonFluid
+            as={ButtonLink}
             href={`/securityTokens/${securityTokenSymbol}/dividends/${
               dividend.index
             }`}

--- a/packages/new-polymath-issuer/src/components/DividendList/Container.tsx
+++ b/packages/new-polymath-issuer/src/components/DividendList/Container.tsx
@@ -3,10 +3,7 @@ import { connect } from 'react-redux';
 import { Dispatch } from 'redux';
 import { DividendListPresenter } from './Presenter';
 import { DataFetcher } from '~/components/enhancers/DataFetcher';
-import {
-  createDividendsByCheckpointFetcher,
-  createTaxWithholdingListBySymbolFetcher,
-} from '~/state/fetchers';
+import { createDividendsByCheckpointFetcher } from '~/state/fetchers';
 import { types } from '@polymathnetwork/new-shared';
 
 export interface Props {

--- a/packages/new-polymath-issuer/src/components/DividendList/Container.tsx
+++ b/packages/new-polymath-issuer/src/components/DividendList/Container.tsx
@@ -3,7 +3,10 @@ import { connect } from 'react-redux';
 import { Dispatch } from 'redux';
 import { DividendListPresenter } from './Presenter';
 import { DataFetcher } from '~/components/enhancers/DataFetcher';
-import { createDividendsByCheckpointFetcher } from '~/state/fetchers';
+import {
+  createDividendsByCheckpointFetcher,
+  createTaxWithholdingListBySymbolFetcher,
+} from '~/state/fetchers';
 import { types } from '@polymathnetwork/new-shared';
 
 export interface Props {


### PR DESCRIPTION
**Please make sure the following boxes are checked before submitting your Pull Request:**

- [x] I've added this PR's link to its Asana task(s)
- [ ] If this PR adds new code that is not going to change in the near future, it includes unit tests to cover it.

This PR:
- Displays actual data in the Dividend Card and fixes the "View Details" button
- Disables the "add new dividend distribution" button if the previous distribution hasn't been completed