### PR TITLE
fix(new-issuer): use actual tokenholders to calculate amounts

### DIFF
--- a/packages/new-polymath-issuer/src/pages/DividendsWizard/Presenter.tsx
+++ b/packages/new-polymath-issuer/src/pages/DividendsWizard/Presenter.tsx
@@ -85,12 +85,14 @@ export class Presenter extends Component<Props, State> {
     );
   };
 
-  public getInvestorAddresses = () => {
+  public getTokenHolderAddresses = () => {
     const {
       checkpoint: { investorBalances },
     } = this.props;
 
-    return investorBalances.map(({ address }) => address.toUpperCase());
+    const tokenHolders = investorBalances.filter(({ balance }) => balance.gt(0));
+
+    return tokenHolders.map(({ address }) => address.toUpperCase());
   };
 
   public renderStepComponent = () => {
@@ -106,7 +108,7 @@ export class Presenter extends Component<Props, State> {
     const { excludedWallets } = this.state;
     const exclusionList = this.getExcludedAddresses();
     const nonExcludedInvestors = difference(
-      this.getInvestorAddresses(),
+      this.getTokenHolderAddresses(),
       exclusionList
     );
 
@@ -157,8 +159,8 @@ export class Presenter extends Component<Props, State> {
     const { dividendAmount, positiveWithholdingAmount } = this.state;
     const { investorBalances } = checkpoint;
     const exclusionList = this.getExcludedAddresses();
-    const investors = this.getInvestorAddresses();
-    const excludedInvestors = intersection(investors, exclusionList);
+    const tokenHolders = this.getTokenHolderAddresses();
+    const excludedInvestors = intersection(tokenHolders, exclusionList);
     const excludedAmount = excludedInvestors.length;
     const investorAmount = investorBalances.length;
     const nonExcludedAmount = investorAmount - excludedAmount;

--- a/packages/new-polymath-issuer/src/pages/DividendsWizard/Step-2/TaxWithholdingModal.tsx
+++ b/packages/new-polymath-issuer/src/pages/DividendsWizard/Step-2/TaxWithholdingModal.tsx
@@ -43,8 +43,8 @@ export const TaxWithholdingModal: FC<Props> = ({
     )) {
       fieldProps.form.setFieldTouched(`${field.name}.${key}`, true, true);
     }
-    const isValid = !get(form.errors, field.name);
-    if (!isValid) {
+    const fieldIsValid = !get(form.errors, field.name);
+    if (!fieldIsValid) {
       return;
     }
 
@@ -54,10 +54,13 @@ export const TaxWithholdingModal: FC<Props> = ({
 
     const value = field.value as TaxWithholdingsItem;
 
+    const valueAddress = value[csvEthAddressKey].toUpperCase();
+    const valuePercentage = value[csvTaxWithholdingKey];
+
     const matchingIndex = findIndex(
       formTaxWithholdings,
       taxWithholding =>
-        taxWithholding[csvEthAddressKey] === value[csvEthAddressKey]
+        taxWithholding[csvEthAddressKey].toUpperCase() === valueAddress
     );
 
     const alreadyExists = matchingIndex !== -1;
@@ -67,10 +70,10 @@ export const TaxWithholdingModal: FC<Props> = ({
       const isUpdated = some(
         existingTaxWithholdings,
         existingTaxWithholding => {
+          const { investorAddress, percentage } = existingTaxWithholding;
           return (
-            existingTaxWithholding.investorAddress.toUpperCase() ===
-              value[csvEthAddressKey].toUpperCase() &&
-            value[csvTaxWithholdingKey] !== existingTaxWithholding.percentage
+            investorAddress.toUpperCase() === valueAddress &&
+            valuePercentage !== percentage
           );
         }
       );

--- a/packages/new-polymath-issuer/src/pages/DividendsWizard/Step-2/index.tsx
+++ b/packages/new-polymath-issuer/src/pages/DividendsWizard/Step-2/index.tsx
@@ -154,7 +154,6 @@ export const Step2: FC<Props> = ({
 
     if (isTaxWithholdingsItemArray(value)) {
       let count = 0;
-
       nonExcludedInvestors.forEach(address => {
         const investorEntry = value.find(
           entry =>
@@ -303,7 +302,12 @@ export const Step2: FC<Props> = ({
               onClick={openCsvModal}
             >
               Upload Tax Withholdings List
-              <Icon Asset={icons.SvgDownload} width={18} height={18} rotate="0.5turn" />
+              <Icon
+                Asset={icons.SvgDownload}
+                width={18}
+                height={18}
+                rotate="0.5turn"
+              />
             </Button>
             <Field
               name="taxWithholdings"


### PR DESCRIPTION
**Please make sure the following boxes are checked before submitting your Pull Request:**

- [x] I've added this PR's link to its Asana task(s)
- [ ] If this PR adds new code that is not going to change in the near future, it includes unit tests to cover it.

This PR uses the investors who actually hold tokens to calculate the numbers in the summary box