### PR TITLE
fix(new-issuer): do not delete label if investor already exists

### DIFF
--- a/packages/new-polymath-issuer/src/pages/DividendsWizard/Step-2/TaxWithholdingModal.tsx
+++ b/packages/new-polymath-issuer/src/pages/DividendsWizard/Step-2/TaxWithholdingModal.tsx
@@ -67,23 +67,20 @@ export const TaxWithholdingModal: FC<Props> = ({
 
     if (isEditing || alreadyExists) {
       // Mark as updated if the entry already existed and was actually updated
-      const isUpdated = some(
-        existingTaxWithholdings,
-        existingTaxWithholding => {
-          const { investorAddress, percentage } = existingTaxWithholding;
-          return (
-            investorAddress.toUpperCase() === valueAddress &&
-            valuePercentage !== percentage
-          );
-        }
-      );
+      const isUpdated = existingTaxWithholdings.find(existingTaxWithholding => {
+        const { investorAddress, percentage } = existingTaxWithholding;
+        return (
+          investorAddress.toUpperCase() === valueAddress &&
+          valuePercentage !== percentage
+        );
+      });
 
       const finalValue = { ...value };
 
       if (isUpdated) {
         finalValue.status = TaxWithholdingStatuses.Updated;
-      } else if (finalValue.status === TaxWithholdingStatuses.Updated) {
-        delete finalValue.status;
+      } else {
+        finalValue.status = TaxWithholdingStatuses.New;
       }
 
       formTaxWithholdings.splice(matchingIndex, 1, finalValue);


### PR DESCRIPTION
**Please make sure the following boxes are checked before submitting your Pull Request:**

- [x] I've added this PR's link to its Asana task(s)
- [ ] If this PR adds new code that is not going to change in the near future, it includes unit tests to cover it.

"'New' or 'Updated' won't be displayed if adding the same investor twice in dividends step 2"