### PR TITLE
fix(new-ui): decimals in percentage input

### DIFF
--- a/packages/new-polymath-ui/src/components/inputs/PercentageInput/PercentageInput.tsx
+++ b/packages/new-polymath-ui/src/components/inputs/PercentageInput/PercentageInput.tsx
@@ -52,7 +52,11 @@ export class PercentageInputPrimitive extends Component<Props> {
       return;
     }
 
-    const normalizedValue = parseFloat(target.value) / 100;
+    const normalizedValue = target.value
+      ? numeral(parseFloat(target.value))
+          .divide(100)
+          .value()
+      : parseFloat(target.value);
     onChange(normalizedValue);
   };
 


### PR DESCRIPTION
**Please make sure the following boxes are checked before submitting your Pull Request:**

- [X] I've added this PR's link to its Asana task(s)
- [ ] If this PR adds new code that is not going to change in the near future, it includes unit tests to cover it.

## This PR: 

Fixes the bug: [Inputting two decimals in the dividends step two translates into a long decimal](https://app.asana.com/0/951808452757493/1114871323437269)

