### PR TITLE
fix: request correct amount from faucet and add faucet validation

### DIFF
--- a/packages/new-polymath-sdk/src/LowLevel/PolyToken.ts
+++ b/packages/new-polymath-sdk/src/LowLevel/PolyToken.ts
@@ -46,9 +46,10 @@ export class PolyToken extends Contract<PolyTokenContract> {
     if (!this.isTestnet) {
       throw new Error('Cannot call "getTokens" in mainnet');
     }
+    const amountInWei = toWei(amount);
     return () =>
       this.contract.methods
-        .getTokens(amount, recipient)
+        .getTokens(amountInWei, recipient)
         .send({ from: this.context.account });
   };
 


### PR DESCRIPTION
**Please make sure the following boxes are checked before submitting your Pull Request:**

- [x] I've added this PR's link to its Asana task(s)
- [ ] If this PR adds new code that is not going to change in the near future, it includes unit tests to cover it.

This PR:
- Adds validation to step 3 of the wizard to prevent the issuer from requesting more than 1M POLY from the faucet (which would otherwise revert because of validation in the contract)
- Properly converts the amount passed to getTokens to wei in the SDK
- Properly checks if the issuer has enough balance before checking if they have already approved the funds (you can technically approve amounts you don't own so you could in theory have enough approval but not enough funds)
- Rounds up the required funds from the faucet to the nearest integer (this isn't a requirement but it doesn't hurt and makes the display in the Tx modal easier on the eyes in case the issuer has a balance with too many decimals)