### PR TITLE
chore(new-ui): add word wrap to dividend card heading

### DIFF
--- a/packages/new-polymath-issuer/src/components/DividendCard/DividendCard.tsx
+++ b/packages/new-polymath-issuer/src/components/DividendCard/DividendCard.tsx
@@ -17,6 +17,7 @@ import {
   ButtonFluid,
 } from '@polymathnetwork/new-ui';
 import { DIVIDEND_PAYMENT_INVESTOR_BATCH_SIZE } from '~/constants';
+import * as sc from './styles';
 
 interface Props {
   dividend: types.DividendEntity;
@@ -88,9 +89,9 @@ export const DividendCard: FC<Props> = ({
             {formatters.toTokens(dividend.amount)} {currencyLabel}
           </Paragraph>
         </CardPrimary>
-        <Heading mt="m" mb={1}>
+        <sc.DividendHeading mt="m" mb={1}>
           {dividend.name}
-        </Heading>
+        </sc.DividendHeading>
         <Label color={currencyColor} bg={currencyBgColor}>
           Issued in {currencyType}
         </Label>

--- a/packages/new-polymath-issuer/src/components/DividendCard/styles.ts
+++ b/packages/new-polymath-issuer/src/components/DividendCard/styles.ts
@@ -6,9 +6,7 @@ export const DividendHeading: StyledComponent<
   ThemeInterface,
   any,
   'variant'
-> = styled(Heading).attrs({
-  variant: 'h2',
-})`
+> = styled(Heading)`
   width: 100%;
   word-wrap: break-word;
 `;

--- a/packages/new-polymath-issuer/src/components/DividendCard/styles.ts
+++ b/packages/new-polymath-issuer/src/components/DividendCard/styles.ts
@@ -1,0 +1,14 @@
+import { styled, Heading, ThemeInterface } from '@polymathnetwork/new-ui';
+import { StyledComponent } from 'styled-components';
+
+export const DividendHeading: StyledComponent<
+  typeof Heading,
+  ThemeInterface,
+  any,
+  'variant'
+> = styled(Heading).attrs({
+  variant: 'h2',
+})`
+  width: 100%;
+  word-wrap: break-word;
+`;

--- a/packages/new-polymath-ui/src/components/Heading/Heading.tsx
+++ b/packages/new-polymath-ui/src/components/Heading/Heading.tsx
@@ -31,6 +31,8 @@ const StyledHeading = styled(Box)<HeadingProps>`
   ${fontWeight};
   ${lineHeight};
   ${fontSize};
+  width: 100%;
+  word-wrap: break-word;
 `;
 
 // TODO @grsmto: remove when https://github.com/pedronauck/docz/issues/337 is resolved

--- a/packages/new-polymath-ui/src/components/Heading/Heading.tsx
+++ b/packages/new-polymath-ui/src/components/Heading/Heading.tsx
@@ -31,8 +31,6 @@ const StyledHeading = styled(Box)<HeadingProps>`
   ${fontWeight};
   ${lineHeight};
   ${fontSize};
-  width: 100%;
-  word-wrap: break-word;
 `;
 
 // TODO @grsmto: remove when https://github.com/pedronauck/docz/issues/337 is resolved


### PR DESCRIPTION
**Please make sure the following boxes are checked before submitting your Pull Request:**

- [x] I've added this PR's link to its Asana task(s)
- [ ] If this PR adds new code that is not going to change in the near future, it includes unit tests to cover it.

## This PR: 

Fixes: 
[Text is not wrapped on the dividends title in the dividends screen](https://app.asana.com/0/427839295975995/1115263376778652)
