### PR TITLE
fix(issuer): ensure countdown disappears when sto is closed

### DIFF
--- a/packages/polymath-issuer/src/pages/sto/components/STOOverview/views/USDTieredSTO/index.js
+++ b/packages/polymath-issuer/src/pages/sto/components/STOOverview/views/USDTieredSTO/index.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { Component } from 'react';
+import React, { Component, useState, useEffect } from 'react';
 import { connect } from 'react-redux';
 import BigNumber from 'bignumber.js';
 import { reduce } from 'lodash';
@@ -106,7 +106,24 @@ const USDTieredSTOOverviewComponent = ({
   sto,
 }: ComponentProps) => {
   const totalUsdRaised = sto.totalUsdRaised;
-  const countdownProps = getCountdownProps(sto);
+
+  const [countdownProps, setCountDown] = useState(getCountdownProps(sto));
+
+  useEffect(() => {
+    const now = new Date();
+    const { startDate, endDate } = sto;
+    if (now < startDate) {
+      const timeUntilStart = startDate - now;
+      setTimeout(() => {
+        setCountDown(getCountdownProps(sto));
+      }, timeUntilStart);
+    } else if (now < endDate) {
+      const timeUntilEnd = endDate - now;
+      setTimeout(() => {
+        setCountDown(getCountdownProps(sto));
+      }, timeUntilEnd);
+    }
+  });
   const totalUsdCap = reduce(
     sto.tiers,
     (total, { totalUsd }) => totalUsd.plus(total),


### PR DESCRIPTION
**Please make sure the following boxes are checked before submitting your Pull Request:**

- [x] I've added this PR's link to its Asana task(s)
- [ ] If this PR adds new code that is not going to change in the near future, it includes unit tests to cover it.

## This PR
Fixes: [USD Tiered STO 'Closed' screen still shows countdown](https://app.asana.com/0/951808452757493/1115358725913804)


