### PR TITLE
fix: fix completed transaction percentage when there are no tokenholders

### DIFF
--- a/packages/new-polymath-issuer/src/pages/DividendDetails/Presenter.tsx
+++ b/packages/new-polymath-issuer/src/pages/DividendDetails/Presenter.tsx
@@ -243,7 +243,7 @@ export const Presenter = ({
                   <Box ml="m">
                     <Text color="highlightText" fontSize={6} fontWeight={0}>
                       {formatters.toPercent(
-                        1 - pendingTransactions / totalTransactions
+                        1 - pendingTransactions / (totalTransactions || 1)
                       )}
                     </Text>
                     <Paragraph>Transactions are completed</Paragraph>

--- a/packages/new-polymath-ui/src/components/utils/contentMappings.ts
+++ b/packages/new-polymath-ui/src/components/utils/contentMappings.ts
@@ -261,6 +261,10 @@ export const getTransactionQueueTitle = (queue: types.TransactionQueuePojo) => {
 
       switch (status) {
         case types.TransactionQueueStatus.Failed: {
+          if (queue.transactions.length === 1) {
+            return `An error occurred with ${content}`;
+          }
+
           return `${content} was partially submitted`;
         }
         case types.TransactionQueueStatus.Idle: {


### PR DESCRIPTION
Also fixed the tx modal language when the payment fails and there is only one transaction

**Please make sure the following boxes are checked before submitting your Pull Request:**

- [x] I've added this PR's link to its Asana task(s)
- [ ] If this PR adds new code that is not going to change in the near future, it includes unit tests to cover it.
