### PR TITLE
fix(new-issuer): confirm unposted transactions

### DIFF
--- a/packages/new-polymath-issuer/src/pages/DividendsWizard/Presenter.tsx
+++ b/packages/new-polymath-issuer/src/pages/DividendsWizard/Presenter.tsx
@@ -28,6 +28,7 @@ import {
   GetErc20BalanceByAddressAndWalletArgs,
   GetIsValidErc20ByAddressArgs,
 } from '~/types';
+import { block, unblock } from 'redux-little-router';
 
 export interface ExclusionEntry {
   ['Investor ETH Address']: string;
@@ -100,6 +101,14 @@ export class Presenter extends Component<Props, State> {
   public setIsDirty = (isDirty: boolean) => {
     if (isDirty !== this.state.isDirty) {
       this.setState({ isDirty });
+      if (isDirty) {
+        window.onbeforeunload = e => {
+          e.preventDefault();
+          return true;
+        };
+      } else {
+        window.onbeforeunload = null;
+      }
     }
   };
 

--- a/packages/new-polymath-issuer/src/pages/DividendsWizard/Presenter.tsx
+++ b/packages/new-polymath-issuer/src/pages/DividendsWizard/Presenter.tsx
@@ -23,7 +23,7 @@ import { ConfirmModal } from './Step-2/ConfirmModal';
 import { Step3 } from './Step-3';
 import { types, formatters } from '@polymathnetwork/new-shared';
 import BigNumber from 'bignumber.js';
-import { difference, intersection, filter } from 'lodash';
+import { difference, intersection } from 'lodash';
 import {
   GetErc20BalanceByAddressAndWalletArgs,
   GetIsValidErc20ByAddressArgs,

--- a/packages/new-polymath-issuer/src/pages/DividendsWizard/Presenter.tsx
+++ b/packages/new-polymath-issuer/src/pages/DividendsWizard/Presenter.tsx
@@ -102,10 +102,17 @@ export class Presenter extends Component<Props, State> {
     if (isDirty !== this.state.isDirty) {
       this.setState({ isDirty });
       if (isDirty) {
+        // Block reload
         window.onbeforeunload = e => {
           e.preventDefault();
           return true;
         };
+        block(() => {
+          return (
+            'To apply your new/modified tax withholding entries, simply hit "CANCEL" and click on "UPDATE" above the Tax Withholdings table.\n' +
+            'To ignore the new/modified tax withholding entries, simply hit "PROCEED"'
+          );
+        });
       } else {
         window.onbeforeunload = null;
       }

--- a/packages/new-polymath-issuer/src/pages/DividendsWizard/Presenter.tsx
+++ b/packages/new-polymath-issuer/src/pages/DividendsWizard/Presenter.tsx
@@ -115,6 +115,7 @@ export class Presenter extends Component<Props, State> {
         });
       } else {
         window.onbeforeunload = null;
+        unblock();
       }
     }
   };

--- a/packages/new-polymath-issuer/src/pages/DividendsWizard/Step-2/index.tsx
+++ b/packages/new-polymath-issuer/src/pages/DividendsWizard/Step-2/index.tsx
@@ -4,7 +4,7 @@ import {
   validateYupSchema,
   yupToFormErrors,
 } from 'formik';
-import React, { Fragment, useState, useMemo, FC } from 'react';
+import React, { Fragment, useState, useMemo, FC, useEffect } from 'react';
 import { types } from '@polymathnetwork/new-shared';
 import {
   Box,
@@ -36,6 +36,7 @@ import {
   FormValues,
   TaxWithholdingStatuses,
 } from './shared';
+import { filter } from 'lodash';
 
 interface Props {
   onNextStep: () => void;
@@ -53,6 +54,7 @@ interface Props {
   exclusionList: string[];
   onTaxWithholdingListChange: (amountOfInvestors: number) => void;
   isLoadingData: boolean;
+  setIsDirty: (isDirty: boolean) => void;
 }
 
 const schema = validator.object().shape({
@@ -85,6 +87,7 @@ export const Step2: FC<Props> = ({
   exclusionList,
   onTaxWithholdingListChange,
   isLoadingData,
+  setIsDirty,
 }) => {
   const [csvModalOpen, setCsvModalOpen] = useState(false);
 
@@ -275,6 +278,7 @@ export const Step2: FC<Props> = ({
             csvModalOpen={csvModalOpen}
             closeCsvModal={closeCsvModal}
             isLoadingData={isLoadingData}
+            setIsDirty={setIsDirty}
           />
         )}
       />
@@ -291,6 +295,7 @@ interface FormProps {
   csvModalOpen: boolean;
   closeCsvModal: () => void;
   isLoadingData: boolean;
+  setIsDirty: (isDirty: boolean) => void;
 }
 
 const Form: FC<FormProps> = ({
@@ -302,12 +307,17 @@ const Form: FC<FormProps> = ({
   csvModalOpen,
   closeCsvModal,
   isLoadingData,
+  setIsDirty,
 }) => {
   const [isEditing, setIsEditing] = useState(false);
   const [confirmModalOpen, setConfirmModalOpen] = useState(false);
   const [taxWithholdingModalOpen, setTaxWithholdingModalOpen] = useState(false);
   const [confirmDeleteModalOpen, setConfirmDeleteModalOpen] = useState(false);
   const [addressesToDelete, setAddressesToDelete] = useState<string[]>([]);
+  useEffect(() => {
+    setIsDirty(isDraft);
+  });
+
   const openTaxWithhholdingModal = () => {
     setTaxWithholdingModalOpen(true);
   };

--- a/packages/new-polymath-issuer/src/pages/DividendsWizard/Step-2/index.tsx
+++ b/packages/new-polymath-issuer/src/pages/DividendsWizard/Step-2/index.tsx
@@ -36,7 +36,7 @@ import {
   FormValues,
   TaxWithholdingStatuses,
 } from './shared';
-import { filter } from 'lodash';
+import { unblock } from 'redux-little-router';
 
 interface Props {
   onNextStep: () => void;
@@ -317,6 +317,13 @@ const Form: FC<FormProps> = ({
   useEffect(() => {
     setIsDirty(isDraft);
   });
+
+  useEffect(() => {
+    return () => {
+      window.onbeforeunload = null;
+      unblock();
+    };
+  }, []);
 
   const openTaxWithhholdingModal = () => {
     setTaxWithholdingModalOpen(true);


### PR DESCRIPTION
**Please make sure the following boxes are checked before submitting your Pull Request:**

- [X] I've added this PR's link to its Asana task(s)
- [ ] If this PR adds new code that is not going to change in the near future, it includes unit tests to cover it.

## This PR:

Fixes the bug [Issuer gets no warning when navigating backwards from dividends step 2 to dividends step 1 while having not submitted investors](https://app.asana.com/0/951808452757493/1115263376778667)

## Notes

If there are transactions that are not posted to the blockchain:

- If the user clicks on `GO BACK` from the wizard, the modal confirm will be displayed.
- If the user clicks on the `refresh` button on the browser or types in a new URL, a native confirm modal will be shown, the text of this modal can not be customized as per [this reference](https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onbeforeunload#Notes). Support for custom text has been removed. So the message bellow will be displayed:
<img width="437" alt="Screen Shot 2019-03-26 at 5 53 24 AM" src="https://user-images.githubusercontent.com/13947919/54987747-7f854680-4f8b-11e9-9e9d-28bf29a077c3.png">


