### PR TITLE
fix(new-issuer): dividends step 1 enforce headers

### DIFF
--- a/packages/new-polymath-issuer/src/pages/DividendsWizard/Step-1/index.tsx
+++ b/packages/new-polymath-issuer/src/pages/DividendsWizard/Step-1/index.tsx
@@ -148,6 +148,7 @@ export const Step1: FC<Step1Props> = ({
                     ],
                     header: true,
                     maxRows: 100,
+                    strict: true,
                     validateFile,
                     customValidationErrorMessage: {
                       header: 'Duplicate Entries',


### PR DESCRIPTION
**Please make sure the following boxes are checked before submitting your Pull Request:**

- [X] I've added this PR's link to its Asana task(s)
- [ ] If this PR adds new code that is not going to change in the near future, it includes unit tests to cover it.

## This PR:

Fixes the issue [Dividends step 1 import doesn't enforce the headers](https://app.asana.com/0/951808452757493/967385233474295)

CSV file is marked as `strict` to prevent extra headers.

<img width="572" alt="Screen Shot 2019-03-28 at 9 27 26 AM" src="https://user-images.githubusercontent.com/13947919/55161351-bac67780-513b-11e9-86c5-1c825fee6704.png">
