### PR TITLE
fix(issuer): tiered sto multi price stuck at 0

### DIFF
--- a/packages/polymath-issuer/src/pages/sto/components/ConfigureSTOForm/forms/USDTieredSTO/TierModal.js
+++ b/packages/polymath-issuer/src/pages/sto/components/ConfigureSTOForm/forms/USDTieredSTO/TierModal.js
@@ -144,7 +144,6 @@ class TierModal extends Component {
               <FormItem.Input
                 component={NumberInput}
                 placeholder="Enter amount"
-                min={0.01}
                 maxDecimals={2}
                 unit="USD"
                 useBigNumbers


### PR DESCRIPTION
**Please make sure the following boxes are checked before submitting your Pull Request:**

- [X] I've added this PR's link to its Asana task(s)
- [ ] If this PR adds new code that is not going to change in the near future, it includes unit tests to cover it.

## This PR:

Fixes the issue [USD Tiered STO price gets stuck at 0.01](https://app.asana.com/0/951808452757493/1116970805613916)

The first fix took care of the `Single`, this PR fixes the same issue on the `Multiple` modal.
