### PR TITLE
Refactor/whitelisting

### DIFF
--- a/packages/polymath-issuer/src/actions/token.js
+++ b/packages/polymath-issuer/src/actions/token.js
@@ -407,7 +407,7 @@ export const mintTokens = () => async (
 
   dispatch(
     ui.tx(
-      ['Whitelisting Addresses', 'Modifying Investor Flags', 'Minting Tokens'],
+      ['Whitelisting Addresses', 'Minting Tokens'],
       async () => {
         await transferManager.modifyKYCDataMulti(uploaded);
         const addresses: Array<Address> = [];

--- a/packages/polymath-issuer/src/utils/contracts/USDTieredSTO.js
+++ b/packages/polymath-issuer/src/utils/contracts/USDTieredSTO.js
@@ -111,18 +111,14 @@ export default class USDTieredSTO {
    * @param statuses statuses for each address matched by index
    */
   async changeAccredited(addresses: string[], statuses: boolean[]) {
-    if (semver.lt(this.version, LATEST_PROTOCOL_VERSION)) {
-      const checksumAddresses = addresses.map(Web3.utils.toChecksumAddress);
+    if (this.version === LATEST_PROTOCOL_VERSION) return;
 
-      await this.legacyContractInstance._tx(
-        this.contract.methods.changeAccredited(checksumAddresses, statuses),
-        null,
-        1.15
-      );
-    } else {
-      const tm = await this.token.contract.getTransferManager();
-      await tm.changeAccredited(addresses, statuses);
-    }
+    const checksumAddresses = addresses.map(Web3.utils.toChecksumAddress);
+    return await this.legacyContractInstance._tx(
+      this.contract.methods.changeAccredited(checksumAddresses, statuses),
+      null,
+      1.15
+    );
   }
 
   /**

--- a/packages/polymath-js/src/contracts/TransferManager.js
+++ b/packages/polymath-js/src/contracts/TransferManager.js
@@ -210,25 +210,8 @@ export default class TransferManager extends Contract {
       toBlock: 'latest',
     });
 
-    // $FlowFixMe
-    const flagEvents = await this._contractWS.getPastEvents(
-      MODIFY_INVESTOR_FLAG,
-      {
-        filter: { _flag: 1 },
-        fromBlock: 0,
-        toBlock: 'latest',
-      }
-    );
-
-    if (events.length !== flagEvents.length) {
-      throw new Error(
-        'Unexpected error occured while retrieving investors whitelist. Please report this issue to Polymath team.'
-      );
-    }
-
     for (let i = 0; i < events.length; i++) {
       const event = events[i];
-      const canBuyFromSTO = !flagEvents[i].returnValues._value;
 
       logs.push({
         address: event.returnValues._investor,
@@ -236,7 +219,6 @@ export default class TransferManager extends Contract {
         from: this._toDate(event.returnValues._canSendAfter),
         to: this._toDate(event.returnValues._expiryTime),
         expiry: this._toDate(event.returnValues._expiryTime),
-        canBuyFromSTO,
       });
     }
     return this._mapLogsToInvestors(logs);

--- a/packages/polymath-js/src/contracts/TransferManager.js
+++ b/packages/polymath-js/src/contracts/TransferManager.js
@@ -80,7 +80,7 @@ export default class TransferManager extends Contract {
       return this.modifyWhitelist(...arguments);
 
     // $FlowFixMe
-    await this._tx(
+    return this._tx(
       this._methods.modifyKYCData(
         investor.address, // $FlowFixMe
         this._toUnixTS(investor.from), // $FlowFixMe
@@ -90,20 +90,25 @@ export default class TransferManager extends Contract {
       null,
       2
     );
+  }
+
+  async modifyInvestorFlag(address: string, flag: Number, value: boolean) {
+    if (semver.lt(this.version, LATEST_PROTOCOL_VERSION)) return;
 
     return this._tx(
-      this._methods.modifyInvestorFlag(
-        investor.address,
-        1, // 1 = 'canNotBuyFromSto'
-        !investor.canBuyFromSTO // We're negating the value because 3.0 flag is negated too.
-      ),
+      this._methods.modifyInvestorFlag(address, flag, value),
       null,
       2
     );
   }
 
-  async changeAccredited(addresses: string[], values: boolean[]) {
-    const flags = Array(addresses.length).fill(0); // 0 = isAccredited
+  async modifyInvestorFlagMulti(
+    addresses: Array<string>,
+    flags: Array<number>,
+    values: Array<boolean>
+  ) {
+    if (semver.lt(this.version, LATEST_PROTOCOL_VERSION)) return;
+
     return this._tx(
       this._methods.modifyInvestorFlagMulti(addresses, flags, values),
       null,
@@ -155,28 +160,15 @@ export default class TransferManager extends Contract {
       fromTimes.push(this._toUnixTS(investor.from)); // $FlowFixMe
       toTimes.push(this._toUnixTS(investor.to)); // $FlowFixMe
       expiryTimes.push(this._toUnixTS(investor.expiry)); // $FlowFixMe
-      flags.push(1); // 1 = 'canNotBuyFromSto'
-      if (investor.hasOwnProperty('canBuyFromSTO')) {
-        // We're negating the value because 3.0 flag is negated too (ie can NOT buy from STO).
-        cannotBuyFromSTO.push(!investor.canBuyFromSTO);
-      } else {
-        cannotBuyFromSTO.push(false);
-      }
     }
 
-    await this._tx(
+    return this._tx(
       this._methods.modifyKYCDataMulti(
         addresses,
         fromTimes,
         toTimes,
         expiryTimes
       ),
-      null,
-      2
-    );
-
-    return this._tx(
-      this._methods.modifyInvestorFlagMulti(addresses, flags, cannotBuyFromSTO),
       null,
       2
     );

--- a/packages/polymath-offchain/src/routes/providers.js
+++ b/packages/polymath-offchain/src/routes/providers.js
@@ -159,7 +159,6 @@ export const checkForReservedTicker = async (
  * @param {string} networkId id of the network the client is connected to
  */
 export const applyHandler = async (ctx: Context) => {
-  console.log('APPLY HANDLER');
   let body = ctx.request.body;
 
   if (!isApplyRequestValid(body)) {

--- a/packages/polymath-offchain/src/routes/providers.js
+++ b/packages/polymath-offchain/src/routes/providers.js
@@ -159,6 +159,7 @@ export const checkForReservedTicker = async (
  * @param {string} networkId id of the network the client is connected to
  */
 export const applyHandler = async (ctx: Context) => {
+  console.log('APPLY HANDLER');
   let body = ctx.request.body;
 
   if (!isApplyRequestValid(body)) {


### PR DESCRIPTION
Refactor whitelisting (import whitelist) so that
- In 3.0, we won't call `modifyInvestorFlag` unless there are related values in uploaded CSV file.
- Same for USDTieredSTO, we won't call `changeNonAccreditedLimit` unless there values in the CSV.
- In 3.0 USDTieredSTO, modify investors accreditation via `modifyInvestorFlag` instead of `changeAccredited`.