### PR TITLE
fix: better error display + stage providers' maintenance page

### DIFF
--- a/packages/polymath-issuer/src/routes.js
+++ b/packages/polymath-issuer/src/routes.js
@@ -1,6 +1,10 @@
 // @flow
 import React from 'react';
-import { NotFoundPage, MaintenancePage } from '@polymathnetwork/ui';
+import {
+  NotFoundPage,
+  MaintenancePage,
+  ProvidersMaintenancePage,
+} from '@polymathnetwork/ui';
 import { Redirect } from 'react-router-dom';
 
 import App from './components/App';

--- a/packages/polymath-offchain/src/routes/providers.js
+++ b/packages/polymath-offchain/src/routes/providers.js
@@ -258,7 +258,7 @@ export const applyHandler = async (ctx: Context) => {
       );
     }
   } catch (error) {
-    console.error('Sendgrid error:', error);
+    console.error('Sendgrid error:', error, error.response.body.errors);
   }
 
   ctx.body = {

--- a/packages/polymath-ui/src/components/ProvidersMaintenancePage/ProvidersMaintenancePage.js
+++ b/packages/polymath-ui/src/components/ProvidersMaintenancePage/ProvidersMaintenancePage.js
@@ -1,0 +1,24 @@
+// @flow
+
+import React, { Component } from 'react';
+
+import { bull } from '@polymathnetwork/ui';
+
+export default class NotFoundPage extends Component<{}> {
+  render() {
+    return (
+      <div className="pui-single-box">
+        <div className="pui-single-box-header">
+          <div className="pui-single-box-bull">
+            <img src={bull} alt="Bull" />
+          </div>
+          <h1 className="pui-h1">Maintenance In Progress</h1>
+          <h3 className="pui-h3">
+            Providers page is temporarily unavailable as it undergoes
+            maintenance.
+          </h3>
+        </div>
+      </div>
+    );
+  }
+}

--- a/packages/polymath-ui/src/components/ProvidersMaintenancePage/index.js
+++ b/packages/polymath-ui/src/components/ProvidersMaintenancePage/index.js
@@ -1,0 +1,3 @@
+import ProvidersMaintenancePage from './ProvidersMaintenancePage';
+
+export default ProvidersMaintenancePage;

--- a/packages/polymath-ui/src/index.js
+++ b/packages/polymath-ui/src/index.js
@@ -48,6 +48,9 @@ export { default as MetamaskStatus } from './components/MetamaskStatus';
 export { default as NotFoundPage } from './components/NotFoundPage';
 export { default as NotSupportedPage } from './components/NotSupportedPage';
 export { default as MaintenancePage } from './components/MaintenancePage';
+export {
+  default as ProvidersMaintenancePage,
+} from './components/ProvidersMaintenancePage';
 export { default as SignUpPage } from './components/SignUpPage';
 export { default as SignUpSuccessPage } from './components/SignUpSuccessPage';
 export { default as SignInPage } from './components/SignInPage';


### PR DESCRIPTION
- Another attempt at catching and printing sendgrid errors.
- Added ProvidersMaintenancePage. To be used later if needed.