### PR TITLE
fix(issuer): fix a regression

### DIFF
--- a/packages/polymath-js/src/contracts/TransferManager.js
+++ b/packages/polymath-js/src/contracts/TransferManager.js
@@ -225,7 +225,7 @@ export default class TransferManager extends Contract {
         address: event.returnValues._investor,
         addedBy: event.returnValues._addedBy,
         from: this._toDate(event.returnValues._canSendAfter),
-        to: this._toDate(event.returnValues._expiryTime),
+        to: this._toDate(event.returnValues._canReceiveAfter),
         expiry: this._toDate(event.returnValues._expiryTime),
       });
     }


### PR DESCRIPTION
While retrieving a whitelist, expiry date was mapped, incorrectly, to canReceiveAfter property.