### PR TITLE
fix(issuer): fix the export of investor flags

### DIFF
--- a/packages/polymath-issuer/src/actions/compliance.js
+++ b/packages/polymath-issuer/src/actions/compliance.js
@@ -628,14 +628,13 @@ export const exportWhitelist = () => async (
     const {
       whitelist: {
         transferManager,
-        percentageTM: { contract: percentageTM },
+        percentageTM: { contract: percentageTM, isPaused: PTMPaused },
       },
       sto,
     } = getState();
 
     const investors = await transferManager.getWhitelist();
-
-    if (percentageTM) {
+    if (percentageTM && !PTMPaused) {
       const percentages = await percentageTM.getWhitelist();
       for (let i = 0; i < investors.length; i++) {
         for (let percentage of percentages) {
@@ -646,7 +645,6 @@ export const exportWhitelist = () => async (
         }
       }
     }
-
     // eslint-disable-next-line max-len
     let csvContent =
       'ETH Address,Sell Restriction Date,Buy Restriction Date,KYC/AML Expiry Date,Can Buy From STO,Exempt From % Ownership,Is Accredited,Non-Accredited Limit';

--- a/packages/polymath-js/src/contracts/TransferManager.js
+++ b/packages/polymath-js/src/contracts/TransferManager.js
@@ -64,7 +64,7 @@ export default class TransferManager extends Contract {
   }
 
   _mapFlagKeyToLabel(flag: number): string {
-    const map = ['accredited', 'canBuyFromSTO', 'isVolRestricted'];
+    const map = ['accredited', 'canNotBuyFromSTO', 'isVolRestricted'];
 
     return map[flag];
   }
@@ -245,16 +245,20 @@ export default class TransferManager extends Contract {
       let flagNumbers = [];
       // Decode investor flags. flags variable is a uint256 representation of the flags, where
       // each bit represents an active flag.
+
+      // Investors can buy from STO, by default.
+      investors[x]['canBuyFromSTO'] = true;
       for (let j = 0; j < 256; j++) {
         if (flags.testn(j)) {
           flagNumbers.push(j);
           const key = this._mapFlagKeyToLabel(j);
-          investors[x][key] = true;
+          // Negate canBuyFromSTO value.
+          if (key === 'canNotBuyFromSTO') {
+            investors[x]['canBuyFromSTO'] = false;
+          } else {
+            investors[x][key] = true;
+          }
         }
-        investors[x].canBuyFromSTO =
-          investors[x].canBuyFromSTO === undefined
-            ? true
-            : !investors[x].canBuyFromSTO;
       }
     }
 


### PR DESCRIPTION
This is the last PR regarding csv import/export. It includes:
- Properly negate smart contract's `canNotBuyFromSTO` into dapp's `canBuyFromSTO`.
- Exclude `Exempt from %` from csv export if `percentageTM` module is paused.
