### PR TITLE
GT-86: fix some typos

### DIFF
--- a/packages/polymath-issuer/src/pages/compliance/CompliancePage.js
+++ b/packages/polymath-issuer/src/pages/compliance/CompliancePage.js
@@ -599,9 +599,9 @@ class CompliancePage extends Component<Props, State> {
               <h1 className="pui-h1">Token Compliance</h1>
               <h3 className="pui-h3">
                 Manage compliance requirements of your tokens. You can import
-                and export your whitelist , manage ownership percentages, add
-                3rd party whitelist manager, and manage approval of token
-                transfer between wallets.
+                and export your whitelist, manage ownership percentages, add 3rd
+                party whitelist managers, and manage approval of token transfers
+                between wallets.
               </h3>
             </Grid.Col>
             <Grid.Col style={{ alignSelf: 'center' }}>


### PR DESCRIPTION
Tacking those issues:
- "add 3rd party whitelist manager" should be: "add 3rd party whitelist manager*s*"
- "and manage approval of token transfer between wallets" should be "and manage approval of token transfer*s* between *particular*wallets."
- just noticed one more thing: please remove the space before the comma after "import and export your whitelist"


